### PR TITLE
FR13: Expiry notification via HA Repairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ When setting up a Trip event, you configure:
 - **Start Date**: When the trip begins (Format: YYYY-MM-DD)
 - **End Date**: When the trip ends (Format: YYYY-MM-DD)
 - **Image** *(optional)*: Upload a file or enter a path — [see Image Management](#image-management). Default: blue airplane icon.
+- **URL** *(optional)*: A link to a booking page, website or any related URL.
+- **Memo** *(optional)*: Free-text notes — supports Markdown.
+- **Notify when expired** *(optional)*: Create a notification in [HA Repairs](#expiry-notifications) when the trip's end date has passed. Default: off.
 
 ### Available Entities
 
@@ -66,6 +69,8 @@ When setting up a Trip event, you configure:
 - **Days Until End** - Days until trip ends (can become negative if date has passed)
 - **Trip Left Days** - Remaining days during the trip
 - **Trip Left Percent** - Remaining trip percentage (100% before start, decreases during trip, 0% after end)
+- **URL** *(optional)* — Created only when a URL is configured
+- **Memo** *(optional)* — Created only when a memo is configured
 
 #### Binary Sensors
 - **Trip Starts Today** - `true` when the trip starts today
@@ -85,6 +90,9 @@ When setting up a Milestone event, you configure:
 
 - **Target Date**: The important date (Format: YYYY-MM-DD)
 - **Image** *(optional)*: Upload a file or enter a path — [see Image Management](#image-management). Default: red flag icon.
+- **URL** *(optional)*: A link to a website or any related URL.
+- **Memo** *(optional)*: Free-text notes — supports Markdown.
+- **Notify when expired** *(optional)*: Create a notification in [HA Repairs](#expiry-notifications) when the target date has passed. Default: off.
 
 ### Available Entities
 
@@ -98,6 +106,8 @@ When setting up a Milestone event, you configure:
     - `breakdown_weeks` - Weeks component of countdown until target
     - `breakdown_days` - Days component of countdown until target
 - **Days Until** - Days until milestone (can become negative if date has passed)
+- **URL** *(optional)* — Created only when a URL is configured
+- **Memo** *(optional)* — Created only when a memo is configured
 
 #### Binary Sensors
 - **Is Today** - `true` when today is the milestone day
@@ -115,6 +125,8 @@ When setting up an Anniversary event, you configure:
 
 - **Original Date**: The date of the first event (Format: YYYY-MM-DD)
 - **Image** *(optional)*: Upload a file or enter a path — [see Image Management](#image-management). Default: pink heart icon.
+- **URL** *(optional)*: A link to a website or any related URL.
+- **Memo** *(optional)*: Free-text notes — supports Markdown.
 
 ### Available Entities
 
@@ -134,6 +146,8 @@ When setting up an Anniversary event, you configure:
 - **Occurrences Count** - Number of past occurrences
 - **Next Date** - Date of next anniversary (ISO 8601 timestamp)
 - **Last Date** - Date of last anniversary (ISO 8601 timestamp)
+- **URL** *(optional)* — Created only when a URL is configured
+- **Memo** *(optional)* — Created only when a memo is configured
 
 #### Binary Sensors
 - **Is Today** - `true` when today is an anniversary day
@@ -155,6 +169,8 @@ When setting up a Special Event, you configure:
 - **Event Category**: Choose from 4 categories (Traditional Holidays, Calendar Holidays, Daylight Saving Time, Custom Pattern)
 - **Special Event Type**: Choose from 13 predefined holidays — or define your own Custom Pattern
 - **Image** *(optional)*: Upload a file or enter a path — [see Image Management](#image-management). Default: purple star icon.
+- **URL** *(optional)*: A link to a website or any related URL.
+- **Memo** *(optional)*: Free-text notes — supports Markdown.
 
 ### Available Entities
 
@@ -173,6 +189,8 @@ When setting up a Special Event, you configure:
     - `breakdown_days` - Days component of countdown until next
 - **Next Date** - Date of next occurrence (ISO 8601 timestamp)
 - **Last Date** - Date of last occurrence (ISO 8601 timestamp)
+- **URL** *(optional)* — Created only when a URL is configured
+- **Memo** *(optional)* — Created only when a memo is configured
 
 #### Binary Sensors
 - **Is Today** - `true` when today is the special event day
@@ -286,6 +304,13 @@ Depending on the frequency, you then define how the day within the period is sel
 | Until a date | Repeats until a specific date (inclusive) |
 | After N occurrences | Stops after exactly N occurrences |
 
+**Step 4 — Image, URL, Memo and Notifications**
+
+- **Image** *(optional)*: Upload or enter path — [see Image Management](#image-management).
+- **URL** *(optional)*: A link to a website or any related URL.
+- **Memo** *(optional)*: Free-text notes — supports Markdown.
+- **Notify when expired** *(optional)*: Only shown when an end condition is set. Create a notification in [HA Repairs](#expiry-notifications) when the pattern has no more future occurrences. Default: off.
+
 ##### Example Configurations
 
 **1 — Early May Bank Holiday** (1st Monday in May, UK):
@@ -355,6 +380,8 @@ Depending on the frequency, you then define how the day within the period is sel
 - **Next Date** — Timestamp of the next *future* occurrence (never today, even when today is an occurrence)
 - **Last Date** — Timestamp of the most recent occurrence (including today)
 - **Occurrence Count** — How many times the pattern has fired since the anchor date (counting today)
+- **URL** *(optional)* — Created only when a URL is configured
+- **Memo** *(optional)* — Created only when a memo is configured
 
 ###### Binary Sensors
 - **Is Today** — `true` when today is an occurrence day
@@ -487,6 +514,28 @@ The `event_date` sensor provides breakdown attributes for building localized cou
 
 These values are calculated using approximations (365 days/year, 30 days/month) for consistent results. Use these attributes in Lovelace cards or templates to create formatted countdown text in your preferred language.
 
+### Expiry Notifications
+
+WhenHub can notify you when an event's date has passed and the event is no longer relevant. This feature uses Home Assistant's built-in **Repairs** panel.
+
+**Supported event types:**
+- **Trip** — notifies when the end date has passed
+- **Milestone** — notifies when the target date has passed
+- **Custom Pattern** — notifies when the pattern has no more future occurrences (only available when an end condition is configured)
+
+**How to enable:**
+Enable **Notify when expired** in the event's configuration (or Options Flow). The toggle is off by default.
+
+**How it works:**
+1. WhenHub detects on every update cycle that the event has expired
+2. A fixable issue appears in **Settings → System → Repairs**
+3. Click **Fix** to open a confirmation dialog
+4. Confirm to permanently remove the event and all its entities
+
+> **Before confirming:** Check if any dashboards, automations, or scripts reference this event's entities — they will stop working after removal. You can also dismiss the notification to keep the event unchanged.
+
+**Auto-resolve:** If you update the event's dates (via Options Flow) so that it is no longer expired, the Repairs notification disappears automatically on the next update cycle.
+
 ### Options Flow
 
 All event configurations can be edited after initial setup via the **Options Flow**:
@@ -503,7 +552,7 @@ All sensors are automatically updated with the new data.
 
 | Property | Value |
 |----------|-------|
-| Update Interval | Once per day (at midnight) |
+| Update Interval | Once per hour |
 | IoT Class | `calculated` |
 | Platforms | Sensor, Binary Sensor, Image, Calendar |
 | Config Flow | Full UI configuration |

--- a/custom_components/whenhub/__init__.py
+++ b/custom_components/whenhub/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant.helpers.issue_registry import async_delete_issue
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -96,6 +97,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, platforms):
+        # Clean up any open Repairs issue for this entry
+        async_delete_issue(hass, DOMAIN, f"expired_{entry.entry_id}")
+
         hass.data[DOMAIN].pop(entry.entry_id)
 
         entity_registry = er.async_get(hass)

--- a/custom_components/whenhub/config_flow.py
+++ b/custom_components/whenhub/config_flow.py
@@ -73,6 +73,7 @@ from .const import (
     CONF_CP_COUNT,
     CONF_URL,
     CONF_MEMO,
+    CONF_NOTIFY_ON_EXPIRY,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -154,6 +155,19 @@ def _schema_url_memo(current: dict) -> dict:
         vol.Optional(CONF_MEMO, default=current.get(CONF_MEMO, "")): TextSelector(
             TextSelectorConfig(multiline=True)
         ),
+    }
+
+
+def _schema_notify_on_expiry(current: dict) -> dict:
+    """Return voluptuous field dict for the expiry notification toggle.
+
+    Intended to be spread into a larger vol.Schema dict.
+    """
+    return {
+        vol.Optional(
+            CONF_NOTIFY_ON_EXPIRY,
+            default=current.get(CONF_NOTIFY_ON_EXPIRY, False),
+        ): BooleanSelector(),
     }
 
 
@@ -518,6 +532,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_END_DATE, default=current.get(CONF_END_DATE, date.today().isoformat())): DateSelector(),
             **_schema_image(current),
             **_schema_url_memo(current),
+            **_schema_notify_on_expiry(current),
         })
 
         return self.async_show_form(
@@ -550,6 +565,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_TARGET_DATE, default=current.get(CONF_TARGET_DATE, date.today().isoformat())): DateSelector(),
             **_schema_image(current),
             **_schema_url_memo(current),
+            **_schema_notify_on_expiry(current),
         })
 
         return self.async_show_form(
@@ -1002,6 +1018,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             vol.Required(CONF_END_DATE, default=current_data.get(CONF_END_DATE, date.today().isoformat())): DateSelector(),
             **_schema_image(self.config_entry.data, show_delete=has_image),
             **_schema_url_memo(self.config_entry.data),
+            **_schema_notify_on_expiry(self.config_entry.data),
         })
 
         return self.async_show_form(
@@ -1035,6 +1052,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             vol.Required(CONF_TARGET_DATE, default=current_data.get(CONF_TARGET_DATE, date.today().isoformat())): DateSelector(),
             **_schema_image(current_data, show_delete=has_image),
             **_schema_url_memo(current_data),
+            **_schema_notify_on_expiry(current_data),
         })
 
         return self.async_show_form(
@@ -1422,13 +1440,21 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     ) -> FlowResult:
         """Final step: optional image upload and/or path."""
         current_data = self.config_entry.data
+        merged = {**current_data, **self._cp_data}
         has_image = bool(current_data.get("image_data") or current_data.get(CONF_IMAGE_PATH))
+        has_end = merged.get(CONF_CP_END_TYPE, "none") != "none"
         if user_input is None:
+            if has_end:
+                data_schema = vol.Schema({
+                    **_schema_image(merged, show_delete=has_image),
+                    **_schema_url_memo(merged),
+                    **_schema_notify_on_expiry(merged),
+                })
+            else:
+                data_schema = _schema_cp_image(merged, show_delete=has_image)
             return self.async_show_form(
                 step_id="cp_image",
-                data_schema=_schema_cp_image(
-                    {**current_data, **self._cp_data}, show_delete=has_image
-                ),
+                data_schema=data_schema,
             )
         self._cp_data[CONF_IMAGE_PATH] = user_input.get(CONF_IMAGE_PATH, "")
         if user_input.get(CONF_IMAGE_UPLOAD):
@@ -1437,6 +1463,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self._cp_data[CONF_IMAGE_DELETE] = True
         self._cp_data[CONF_URL] = user_input.get(CONF_URL, "")
         self._cp_data[CONF_MEMO] = user_input.get(CONF_MEMO, "")
+        if has_end:
+            self._cp_data[CONF_NOTIFY_ON_EXPIRY] = user_input.get(CONF_NOTIFY_ON_EXPIRY, False)
+        else:
+            self._cp_data[CONF_NOTIFY_ON_EXPIRY] = False
         return self._cp_save_options()
 
     def _cp_save_options(self) -> FlowResult:

--- a/custom_components/whenhub/const.py
+++ b/custom_components/whenhub/const.py
@@ -64,6 +64,9 @@ CONF_IMAGE_DELETE = "image_delete"  # UI-only checkbox: remove existing image in
 CONF_URL = "url"
 CONF_MEMO = "memo"
 
+# FR13: Expiry notification via HA Repairs
+CONF_NOTIFY_ON_EXPIRY = "notify_on_expiry"
+
 # Default values
 DEFAULT_IMAGE = "/local/whenhub/default_event.png"
 

--- a/custom_components/whenhub/coordinator.py
+++ b/custom_components/whenhub/coordinator.py
@@ -10,6 +10,7 @@ import logging
 from datetime import date, datetime, timedelta
 from typing import Any
 
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue, async_delete_issue
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -26,6 +27,9 @@ from .const import (
     CONF_SPECIAL_CATEGORY,
     CONF_DST_TYPE,
     CONF_DST_REGION,
+    CONF_NOTIFY_ON_EXPIRY,
+    CONF_CP_END_TYPE,
+    CONF_CP_UNTIL,
     EVENT_TYPE_TRIP,
     EVENT_TYPE_MILESTONE,
     EVENT_TYPE_ANNIVERSARY,
@@ -139,6 +143,8 @@ class WhenHubCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             data.update(self._calculate_anniversary_data(today))
         elif self.event_type == EVENT_TYPE_SPECIAL:
             data.update(self._calculate_special_data(today))
+
+        self._check_expiry_repair(today)
 
         return data
 
@@ -339,3 +345,68 @@ class WhenHubCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # Binary sensor values
             "is_today": is_today_val,
         }
+
+    def _check_expiry_repair(self, today: date) -> None:
+        """Create or delete a Repairs issue based on event expiry state.
+
+        Called on every coordinator update cycle. Idempotent — calling
+        async_create_issue repeatedly with the same issue_id is safe in HA.
+        """
+        issue_id = f"expired_{self.config_entry.entry_id}"
+        notify = self.event_data.get(CONF_NOTIFY_ON_EXPIRY, False)
+
+        if not notify:
+            # Clean up if the toggle was turned off after expiry was reported
+            async_delete_issue(self.hass, DOMAIN, issue_id)
+            return
+
+        is_expired = False
+        expiry_date = ""
+
+        if self.event_type == EVENT_TYPE_TRIP:
+            end_date = parse_date(self.event_data.get(CONF_END_DATE, ""))
+            if end_date is not None and end_date < today:
+                is_expired = True
+                expiry_date = end_date.isoformat()
+
+        elif self.event_type == EVENT_TYPE_MILESTONE:
+            target_date = parse_date(self.event_data.get(CONF_TARGET_DATE, ""))
+            if target_date is not None and target_date < today:
+                is_expired = True
+                expiry_date = target_date.isoformat()
+
+        elif self.event_type == EVENT_TYPE_SPECIAL:
+            special_category = self.event_data.get(CONF_SPECIAL_CATEGORY)
+            if special_category == "custom_pattern":
+                cp_end_type = self.event_data.get(CONF_CP_END_TYPE, "none")
+                if cp_end_type != "none":
+                    next_occurrence = next_custom_pattern(self.event_data, today)
+                    if next_occurrence is None:
+                        is_expired = True
+                        until = self.event_data.get(CONF_CP_UNTIL)
+                        if until:
+                            expiry_date = until
+                        else:
+                            last = last_custom_pattern(self.event_data, today)
+                            expiry_date = last.isoformat() if last else ""
+
+        if is_expired:
+            async_create_issue(
+                self.hass,
+                DOMAIN,
+                issue_id,
+                is_fixable=True,
+                severity=IssueSeverity.WARNING,
+                translation_key="expired_event",
+                translation_placeholders={
+                    "event_name": self.config_entry.title,
+                    "expiry_date": expiry_date,
+                },
+                data={
+                    "entry_id": self.config_entry.entry_id,
+                    "event_name": self.config_entry.title,
+                    "expiry_date": expiry_date,
+                },
+            )
+        else:
+            async_delete_issue(self.hass, DOMAIN, issue_id)

--- a/custom_components/whenhub/repairs.py
+++ b/custom_components/whenhub/repairs.py
@@ -1,0 +1,76 @@
+"""HA Repairs integration for WhenHub — expired event notifications.
+
+When an event expires and the user has opted in via CONF_NOTIFY_ON_EXPIRY,
+a Repairs issue is created. The fix flow offers to remove the config entry.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Return the repair flow for a WhenHub issue."""
+    return WhenHubRepairsFlow(issue_id, data)
+
+
+class WhenHubRepairsFlow(RepairsFlow):
+    """Repair flow for an expired WhenHub event.
+
+    Presents a confirmation step with a warning about dashboards/automations,
+    then removes the config entry on confirmation.
+    """
+
+    def __init__(
+        self,
+        issue_id: str,
+        data: dict[str, str | int | float | None] | None,
+    ) -> None:
+        """Initialize the repair flow."""
+        self._issue_id = issue_id
+        self._data = data or {}
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Entry point — forward to confirm step."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Show confirmation form, then remove the entry on submit."""
+        if user_input is not None:
+            entry_id = self._data.get("entry_id")
+            if entry_id:
+                entry = self.hass.config_entries.async_get_entry(entry_id)
+                if entry:
+                    await self.hass.config_entries.async_remove(entry_id)
+                    _LOGGER.info(
+                        "WhenHub: removed expired event entry %s via Repairs fix flow",
+                        entry_id,
+                    )
+            return self.async_create_entry(data={})
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "event_name": self._data.get("event_name", ""),
+                "expiry_date": self._data.get("expiry_date", ""),
+            },
+        )

--- a/custom_components/whenhub/translations/de.json
+++ b/custom_components/whenhub/translations/de.json
@@ -615,7 +615,6 @@
   "issues": {
     "expired_event": {
       "title": "WhenHub Event abgelaufen: {event_name}",
-      "description": "Das Event **{event_name}** ist am {expiry_date} abgelaufen. Klicke auf Reparieren, um es aus Home Assistant zu entfernen, oder schließe die Meldung, um es zu behalten.",
       "fix_flow": {
         "step": {
           "confirm": {

--- a/custom_components/whenhub/translations/de.json
+++ b/custom_components/whenhub/translations/de.json
@@ -17,7 +17,8 @@
           "image_upload": "Bild hochladen (optional)",
           "image_path": "Oder Bildpfad eingeben (optional)",
           "url": "URL (optional)",
-          "memo": "Memo (optional)"
+          "memo": "Memo (optional)",
+          "notify_on_expiry": "Benachrichtigung bei Ablauf"
         },
         "data_description": {
           "start_date": "Das Datum, an dem der Trip beginnt",
@@ -25,7 +26,8 @@
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/trip.jpg — Upload hat Vorrang",
           "url": "Link zur Buchungsseite, Website oder einer anderen relevanten URL",
-          "memo": "Freitext-Notizen zu diesem Event — Markdown wird unterstützt"
+          "memo": "Freitext-Notizen zu diesem Event — Markdown wird unterstützt",
+          "notify_on_expiry": "Erstellt eine Meldung in HA-Reparaturen, wenn dieses Event abgelaufen ist"
         }
       },
       "milestone": {
@@ -36,14 +38,16 @@
           "image_upload": "Bild hochladen (optional)",
           "image_path": "Oder Bildpfad eingeben (optional)",
           "url": "URL (optional)",
-          "memo": "Memo (optional)"
+          "memo": "Memo (optional)",
+          "notify_on_expiry": "Benachrichtigung bei Ablauf"
         },
         "data_description": {
           "target_date": "Das Datum des wichtigen Termins",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/milestone.jpg — Upload hat Vorrang",
           "url": "Link zu einer Website oder einer anderen relevanten URL",
-          "memo": "Freitext-Notizen zu diesem Event — Markdown wird unterstützt"
+          "memo": "Freitext-Notizen zu diesem Event — Markdown wird unterstützt",
+          "notify_on_expiry": "Erstellt eine Meldung in HA-Reparaturen, wenn dieses Event abgelaufen ist"
         }
       },
       "anniversary": {
@@ -236,13 +240,15 @@
           "image_path": "Oder Bildpfad eingeben (optional)",
           "image_delete": "Aktuelles Bild entfernen",
           "url": "URL (optional)",
-          "memo": "Memo (optional)"
+          "memo": "Memo (optional)",
+          "notify_on_expiry": "Benachrichtigung bei Ablauf"
         },
         "data_description": {
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/trip.jpg — Upload hat Vorrang",
           "url": "Link zur Buchungsseite, Website oder einer anderen relevanten URL",
-          "memo": "Freitext-Notizen zu diesem Event — Markdown wird unterstützt"
+          "memo": "Freitext-Notizen zu diesem Event — Markdown wird unterstützt",
+          "notify_on_expiry": "Erstellt eine Meldung in HA-Reparaturen, wenn dieses Event abgelaufen ist"
         }
       },
       "milestone_options": {
@@ -253,13 +259,15 @@
           "image_path": "Oder Bildpfad eingeben (optional)",
           "image_delete": "Aktuelles Bild entfernen",
           "url": "URL (optional)",
-          "memo": "Memo (optional)"
+          "memo": "Memo (optional)",
+          "notify_on_expiry": "Benachrichtigung bei Ablauf"
         },
         "data_description": {
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/milestone.jpg — Upload hat Vorrang",
           "url": "Link zu einer Website oder einer anderen relevanten URL",
-          "memo": "Freitext-Notizen zu diesem Event — Markdown wird unterstützt"
+          "memo": "Freitext-Notizen zu diesem Event — Markdown wird unterstützt",
+          "notify_on_expiry": "Erstellt eine Meldung in HA-Reparaturen, wenn dieses Event abgelaufen ist"
         }
       },
       "anniversary_options": {
@@ -411,13 +419,15 @@
           "image_path": "Oder Bildpfad eingeben",
           "image_delete": "Aktuelles Bild entfernen",
           "url": "URL (optional)",
-          "memo": "Memo (optional)"
+          "memo": "Memo (optional)",
+          "notify_on_expiry": "Benachrichtigung bei Ablauf"
         },
         "data_description": {
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/event.jpg — Upload hat Vorrang",
           "url": "Link zu einer Website oder einer anderen relevanten URL",
-          "memo": "Freitext-Notizen zu diesem Event — Markdown wird unterstützt"
+          "memo": "Freitext-Notizen zu diesem Event — Markdown wird unterstützt",
+          "notify_on_expiry": "Erstellt eine Meldung in HA-Reparaturen, wenn dieses Muster keine zukünftigen Vorkommen mehr hat"
         }
       }
     }
@@ -599,6 +609,20 @@
     "image": {
       "event_image": {
         "name": "Ereignisbild"
+      }
+    }
+  },
+  "issues": {
+    "expired_event": {
+      "title": "WhenHub Event abgelaufen: {event_name}",
+      "description": "Das Event **{event_name}** ist am {expiry_date} abgelaufen. Klicke auf Reparieren, um es aus Home Assistant zu entfernen, oder schließe die Meldung, um es zu behalten.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Abgelaufenes Event entfernen",
+            "description": "**{event_name}** ist am **{expiry_date}** abgelaufen.\n\nVor der Bestätigung: Prüfe ob Dashboards, Automationen oder Skripte auf Entitäten dieses Events zugreifen — sie werden nach der Entfernung nicht mehr funktionieren.\n\nAuf Absenden klicken, um das Event und alle seine Entitäten dauerhaft zu entfernen."
+          }
+        }
       }
     }
   }

--- a/custom_components/whenhub/translations/en.json
+++ b/custom_components/whenhub/translations/en.json
@@ -17,7 +17,8 @@
           "image_upload": "Upload image (optional)",
           "image_path": "Or enter image path (optional)",
           "url": "URL (optional)",
-          "memo": "Memo (optional)"
+          "memo": "Memo (optional)",
+          "notify_on_expiry": "Notify when expired"
         },
         "data_description": {
           "start_date": "The date when the trip begins",
@@ -25,7 +26,8 @@
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/trip.jpg — upload above takes priority",
           "url": "Link to a website, booking page or any related URL",
-          "memo": "Free-text notes about this event — supports Markdown"
+          "memo": "Free-text notes about this event — supports Markdown",
+          "notify_on_expiry": "Create a notification in HA Repairs when this event expires"
         }
       },
       "milestone": {
@@ -36,14 +38,16 @@
           "image_upload": "Upload image (optional)",
           "image_path": "Or enter image path (optional)",
           "url": "URL (optional)",
-          "memo": "Memo (optional)"
+          "memo": "Memo (optional)",
+          "notify_on_expiry": "Notify when expired"
         },
         "data_description": {
           "target_date": "The date of the important event",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/milestone.jpg — upload above takes priority",
           "url": "Link to a website or any related URL",
-          "memo": "Free-text notes about this event — supports Markdown"
+          "memo": "Free-text notes about this event — supports Markdown",
+          "notify_on_expiry": "Create a notification in HA Repairs when this event expires"
         }
       },
       "anniversary": {
@@ -236,13 +240,15 @@
           "image_path": "Or enter image path (optional)",
           "image_delete": "Remove current image",
           "url": "URL (optional)",
-          "memo": "Memo (optional)"
+          "memo": "Memo (optional)",
+          "notify_on_expiry": "Notify when expired"
         },
         "data_description": {
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/trip.jpg — upload above takes priority",
           "url": "Link to a website, booking page or any related URL",
-          "memo": "Free-text notes about this event — supports Markdown"
+          "memo": "Free-text notes about this event — supports Markdown",
+          "notify_on_expiry": "Create a notification in HA Repairs when this event expires"
         }
       },
       "milestone_options": {
@@ -253,13 +259,15 @@
           "image_path": "Or enter image path (optional)",
           "image_delete": "Remove current image",
           "url": "URL (optional)",
-          "memo": "Memo (optional)"
+          "memo": "Memo (optional)",
+          "notify_on_expiry": "Notify when expired"
         },
         "data_description": {
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/milestone.jpg — upload above takes priority",
           "url": "Link to a website or any related URL",
-          "memo": "Free-text notes about this event — supports Markdown"
+          "memo": "Free-text notes about this event — supports Markdown",
+          "notify_on_expiry": "Create a notification in HA Repairs when this event expires"
         }
       },
       "anniversary_options": {
@@ -411,13 +419,15 @@
           "image_path": "Or enter image path",
           "image_delete": "Remove current image",
           "url": "URL (optional)",
-          "memo": "Memo (optional)"
+          "memo": "Memo (optional)",
+          "notify_on_expiry": "Notify when expired"
         },
         "data_description": {
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/event.jpg — upload above takes priority",
           "url": "Link to a website or any related URL",
-          "memo": "Free-text notes about this event — supports Markdown"
+          "memo": "Free-text notes about this event — supports Markdown",
+          "notify_on_expiry": "Create a notification in HA Repairs when this repeating event has no more future occurrences"
         }
       }
     }
@@ -599,6 +609,20 @@
     "image": {
       "event_image": {
         "name": "Event image"
+      }
+    }
+  },
+  "issues": {
+    "expired_event": {
+      "title": "WhenHub event expired: {event_name}",
+      "description": "The event **{event_name}** has expired on {expiry_date}. Click Fix to remove it from Home Assistant, or dismiss to keep it.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Remove expired event",
+            "description": "**{event_name}** expired on **{expiry_date}**.\n\nBefore confirming: check if any dashboards, automations or scripts reference this event's entities — they will stop working after removal.\n\nPress Submit to permanently remove this event and all its entities."
+          }
+        }
       }
     }
   }

--- a/custom_components/whenhub/translations/en.json
+++ b/custom_components/whenhub/translations/en.json
@@ -615,7 +615,6 @@
   "issues": {
     "expired_event": {
       "title": "WhenHub event expired: {event_name}",
-      "description": "The event **{event_name}** has expired on {expiry_date}. Click Fix to remove it from Home Assistant, or dismiss to keep it.",
       "fix_flow": {
         "step": {
           "confirm": {

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,0 +1,350 @@
+"""Tests for FR13: Expiry notification via HA Repairs.
+
+Tests the _check_expiry_repair() logic in WhenHubCoordinator using mocked
+HA repairs functions and lightweight stubs — no HA runtime required.
+"""
+from __future__ import annotations
+
+import sys
+import os
+from datetime import date
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from custom_components.whenhub.const import (
+    DOMAIN,
+    CONF_NOTIFY_ON_EXPIRY,
+    CONF_START_DATE,
+    CONF_END_DATE,
+    CONF_TARGET_DATE,
+    CONF_CP_END_TYPE,
+    CONF_CP_UNTIL,
+    CONF_CP_DTSTART,
+    CONF_CP_FREQ,
+    CONF_CP_INTERVAL,
+    CONF_CP_DAY_RULE,
+    CONF_CP_BYDAY_LIST,
+    CONF_SPECIAL_CATEGORY,
+    EVENT_TYPE_TRIP,
+    EVENT_TYPE_MILESTONE,
+    EVENT_TYPE_ANNIVERSARY,
+    EVENT_TYPE_SPECIAL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+class _FakeHass:
+    """Minimal hass stub — repairs functions are patched at module level."""
+
+
+class _FakeConfigEntry:
+    def __init__(self, entry_id="test_id", title="Test Event"):
+        self.entry_id = entry_id
+        self.title = title
+
+
+def _make_coordinator(event_type: str, event_data: dict):
+    """Create a WhenHubCoordinator instance bypassing __init__."""
+    from custom_components.whenhub.coordinator import WhenHubCoordinator
+
+    coord = object.__new__(WhenHubCoordinator)
+    coord.hass = _FakeHass()
+    coord.config_entry = _FakeConfigEntry()
+    coord.event_type = event_type
+    coord.event_data = event_data
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# Helper: patch both repairs functions and return mocks
+# ---------------------------------------------------------------------------
+
+PATCH_CREATE = "custom_components.whenhub.coordinator.async_create_issue"
+PATCH_DELETE = "custom_components.whenhub.coordinator.async_delete_issue"
+
+
+# ---------------------------------------------------------------------------
+# Trip expiry tests
+# ---------------------------------------------------------------------------
+
+class TestTripExpiry:
+    """_check_expiry_repair for EVENT_TYPE_TRIP."""
+
+    def test_no_action_when_toggle_off(self):
+        """With notify_on_expiry=False, only delete is called (cleanup)."""
+        data = {
+            CONF_END_DATE: "2020-01-01",  # past
+            CONF_NOTIFY_ON_EXPIRY: False,
+        }
+        coord = _make_coordinator(EVENT_TYPE_TRIP, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_create.assert_not_called()
+        mock_delete.assert_called_once_with(
+            coord.hass, DOMAIN, f"expired_{coord.config_entry.entry_id}"
+        )
+
+    def test_create_issue_when_trip_expired(self):
+        """Issue created when end_date is in the past and toggle is on."""
+        data = {
+            CONF_END_DATE: "2024-12-31",
+            CONF_NOTIFY_ON_EXPIRY: True,
+        }
+        coord = _make_coordinator(EVENT_TYPE_TRIP, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_delete.assert_not_called()
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args
+        assert kwargs[0][0] is coord.hass
+        assert kwargs[0][1] == DOMAIN
+        assert kwargs[0][2] == f"expired_{coord.config_entry.entry_id}"
+        assert kwargs[1]["is_fixable"] is True
+        assert kwargs[1]["translation_key"] == "expired_event"
+        assert kwargs[1]["data"]["expiry_date"] == "2024-12-31"
+        assert kwargs[1]["data"]["entry_id"] == coord.config_entry.entry_id
+
+    def test_delete_issue_when_trip_not_yet_expired(self):
+        """Issue deleted when end_date is today or in the future."""
+        data = {
+            CONF_END_DATE: "2026-05-01",  # today — not expired
+            CONF_NOTIFY_ON_EXPIRY: True,
+        }
+        coord = _make_coordinator(EVENT_TYPE_TRIP, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_create.assert_not_called()
+        mock_delete.assert_called_once()
+
+    def test_delete_issue_when_trip_future(self):
+        """Issue deleted when end_date is clearly in the future."""
+        data = {
+            CONF_END_DATE: "2028-01-01",
+            CONF_NOTIFY_ON_EXPIRY: True,
+        }
+        coord = _make_coordinator(EVENT_TYPE_TRIP, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_create.assert_not_called()
+        mock_delete.assert_called_once()
+
+    def test_expired_day_after_end_date(self):
+        """Trip is expired the day after end_date."""
+        data = {
+            CONF_END_DATE: "2026-04-30",
+            CONF_NOTIFY_ON_EXPIRY: True,
+        }
+        coord = _make_coordinator(EVENT_TYPE_TRIP, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE):
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_create.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Milestone expiry tests
+# ---------------------------------------------------------------------------
+
+class TestMilestoneExpiry:
+    """_check_expiry_repair for EVENT_TYPE_MILESTONE."""
+
+    def test_create_issue_when_milestone_expired(self):
+        """Issue created when target_date is in the past and toggle is on."""
+        data = {
+            CONF_TARGET_DATE: "2023-06-15",
+            CONF_NOTIFY_ON_EXPIRY: True,
+        }
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_delete.assert_not_called()
+        mock_create.assert_called_once()
+        assert mock_create.call_args[1]["data"]["expiry_date"] == "2023-06-15"
+
+    def test_delete_issue_when_milestone_not_expired(self):
+        """Issue deleted when target_date is today or future."""
+        data = {
+            CONF_TARGET_DATE: "2026-05-01",  # today
+            CONF_NOTIFY_ON_EXPIRY: True,
+        }
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_create.assert_not_called()
+        mock_delete.assert_called_once()
+
+    def test_no_action_when_toggle_off_milestone(self):
+        """With notify_on_expiry=False, only cleanup delete is called."""
+        data = {
+            CONF_TARGET_DATE: "2020-01-01",  # past
+            CONF_NOTIFY_ON_EXPIRY: False,
+        }
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_create.assert_not_called()
+        mock_delete.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Anniversary — should never trigger expiry
+# ---------------------------------------------------------------------------
+
+class TestAnniversaryNoExpiry:
+    """Anniversary events are recurring — never expire."""
+
+    def test_no_issue_created_for_anniversary(self):
+        """Anniversary events ignore the expiry check entirely."""
+        data = {
+            CONF_TARGET_DATE: "2000-01-01",
+            CONF_NOTIFY_ON_EXPIRY: True,
+        }
+        coord = _make_coordinator(EVENT_TYPE_ANNIVERSARY, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        # notify=True but anniversary — neither branch sets is_expired → delete called
+        mock_create.assert_not_called()
+        mock_delete.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Custom Pattern expiry tests
+# ---------------------------------------------------------------------------
+
+def _cp_weekly_data(end_type: str, cp_until: str | None = None, cp_count: int | None = None) -> dict:
+    """Create minimal custom pattern event data for a weekly Monday pattern."""
+    return {
+        "event_type": EVENT_TYPE_SPECIAL,
+        CONF_SPECIAL_CATEGORY: "custom_pattern",
+        CONF_CP_FREQ: "weekly",
+        CONF_CP_INTERVAL: 1,
+        CONF_CP_DTSTART: "2020-01-06",  # Monday
+        CONF_CP_DAY_RULE: "fixed_day",
+        CONF_CP_BYDAY_LIST: [0],          # Monday
+        CONF_CP_END_TYPE: end_type,
+        CONF_CP_UNTIL: cp_until,
+        "cp_count": cp_count,
+        "cp_bymonth": None,
+        "cp_byday_pos": None,
+        "cp_byday_weekday": None,
+        "cp_bymonthday": None,
+        "cp_exdates": [],
+        CONF_NOTIFY_ON_EXPIRY: True,
+    }
+
+
+class TestCustomPatternExpiry:
+    """_check_expiry_repair for custom pattern events."""
+
+    def test_no_expiry_for_open_ended_pattern(self):
+        """Pattern with cp_end_type='none' never expires."""
+        data = _cp_weekly_data(end_type="none")
+        coord = _make_coordinator(EVENT_TYPE_SPECIAL, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_create.assert_not_called()
+        mock_delete.assert_called_once()
+
+    def test_create_issue_when_until_date_passed(self):
+        """Issue created when cp_until is in the past and no future occurrence."""
+        # Weekly on Monday, ended 2024-01-01 — no future occurrences in 2026
+        data = _cp_weekly_data(end_type="until", cp_until="2024-01-01")
+        coord = _make_coordinator(EVENT_TYPE_SPECIAL, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_create.assert_called_once()
+        assert mock_create.call_args[1]["translation_key"] == "expired_event"
+        # expiry_date should be the cp_until date
+        assert mock_create.call_args[1]["data"]["expiry_date"] == "2024-01-01"
+
+    def test_create_issue_when_count_exhausted(self):
+        """Issue created when all occurrences are consumed."""
+        # 3 occurrences starting 2020-01-06 (weekly Monday)
+        # occurrences: 2020-01-06, 2020-01-13, 2020-01-20 — all past
+        data = _cp_weekly_data(end_type="count", cp_count=3)
+        coord = _make_coordinator(EVENT_TYPE_SPECIAL, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_create.assert_called_once()
+
+    def test_no_issue_when_pattern_has_future_occurrences(self):
+        """No issue when cp_until is in the future."""
+        data = _cp_weekly_data(end_type="until", cp_until="2030-01-01")
+        coord = _make_coordinator(EVENT_TYPE_SPECIAL, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_create.assert_not_called()
+        mock_delete.assert_called_once()
+
+    def test_toggle_off_does_not_create_issue_for_cp(self):
+        """Toggle off: no issue created even for expired CP."""
+        data = _cp_weekly_data(end_type="until", cp_until="2024-01-01")
+        data[CONF_NOTIFY_ON_EXPIRY] = False
+        coord = _make_coordinator(EVENT_TYPE_SPECIAL, data)
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        mock_create.assert_not_called()
+        mock_delete.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Issue ID stability
+# ---------------------------------------------------------------------------
+
+class TestIssueId:
+    """Issue ID is stable and matches entry_id."""
+
+    def test_issue_id_uses_entry_id(self):
+        """issue_id is always 'expired_{entry_id}'."""
+        data = {CONF_END_DATE: "2020-01-01", CONF_NOTIFY_ON_EXPIRY: True}
+        coord = _make_coordinator(EVENT_TYPE_TRIP, data)
+        coord.config_entry = _FakeConfigEntry(entry_id="abc123")
+
+        with patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE):
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        assert mock_create.call_args[0][2] == "expired_abc123"
+
+    def test_delete_uses_same_issue_id(self):
+        """Delete call also uses 'expired_{entry_id}'."""
+        data = {CONF_END_DATE: "2028-01-01", CONF_NOTIFY_ON_EXPIRY: True}
+        coord = _make_coordinator(EVENT_TYPE_TRIP, data)
+        coord.config_entry = _FakeConfigEntry(entry_id="xyz999")
+
+        with patch(PATCH_CREATE), patch(PATCH_DELETE) as mock_delete:
+            coord._check_expiry_repair(date(2026, 5, 1))
+
+        assert mock_delete.call_args[0][2] == "expired_xyz999"


### PR DESCRIPTION
## Summary

- Adds opt-in expiry notifications via HA Repairs for Trip, Milestone, and Custom Pattern events
- New `notify_on_expiry` toggle (default: off) in Config Flow and Options Flow
- Creates a fixable Repairs issue when an event expires; auto-resolves when dates are updated
- Fix Flow removes the expired event entry (with dashboard/automation warning)
- New `repairs.py` module; coordinator checks expiry state on each hourly update cycle
- Full translations (en + de) for toggle labels, issue title/description, and fix flow

## Details

**Expiry conditions:**
- Trip: `end_date < today`
- Milestone: `target_date < today`
- Custom Pattern: `cp_end_type ≠ "none"` AND no future occurrences

**Implementation notes:**
- `async_create_issue` / `async_delete_issue` / `IssueSeverity` from `homeassistant.helpers.issue_registry` (not `components.repairs`)
- Issue ID: `expired_{entry_id}` — stable and idempotent
- Cleanup on entry unload via `async_delete_issue` in `async_unload_entry`

## Test plan

- [x] 525 tests pass (16 new in `tests/test_repairs.py`)
- [x] Manual test in HA test system — issue appears in Repairs, Fix Flow removes entry
- [x] Auto-resolve verified: updating dates removes the issue

## Related

- Closes #11
- README updated (FR11 URL/Memo backfill + FR13 expiry notifications)
- Internal plan for `TECHNICAL_REFERENCE.md` update: `docs/TECHREF_UPDATE_PLAN.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)