### PR TITLE
Fix #12: Image upload validation (file type + size limit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Every WhenHub event has an **Event Image** entity. When no image is configured, 
 
 In the configuration form, two options are available — use one or both:
 
-1. **Upload** — Drag & drop or click to select a file directly in the HA config flow. The image is stored inside the config entry — no files to manage on the server. Supported: JPEG, PNG, WebP, GIF.
+1. **Upload** — Drag & drop or click to select a file directly in the HA config flow. The image is stored inside the config entry — no files to manage on the server. Supported formats: JPEG, PNG, WebP, GIF. Maximum file size: 5 MB.
 2. **Path** — Enter a path to an image already on your HA server, e.g. `/local/images/trip.jpg` (files placed in the `www/` directory of your HA config).
 
 **Priority:** If both are provided, the upload takes precedence over the path.

--- a/TECHNICAL_REFERENCE.md
+++ b/TECHNICAL_REFERENCE.md
@@ -399,8 +399,8 @@ Each event includes an image entity that displays either a custom image or a def
 | Special Event | Star | Purple |
 
 **Image sources:**
-1. **Uploaded file**: Stored in HA `www/` directory, path saved in entry data
-2. **Custom path**: `/local/images/my-event.jpg`
+1. **Uploaded file**: Stored as base64 in config entry data — no files on the server. Supported formats: JPEG, PNG, WebP, GIF. Maximum file size: 5 MB. Validation is done server-side in `_process_image_upload()`.
+2. **Custom path**: `/local/images/my-event.jpg` (files placed in the `www/` directory of the HA config)
 3. **Default SVG**: Auto-generated icon based on event type
 
 **Attributes:**
@@ -470,7 +470,7 @@ async_step_user (menu)
 |-----------|------|----------|-------------|
 | `start_date` | date | Yes | Trip start |
 | `end_date` | date | Yes | Trip end |
-| `image_upload` | file | No | Upload image (JPEG/PNG/WebP/GIF) |
+| `image_upload` | file | No | Upload image (JPEG/PNG/WebP/GIF, max 5 MB) |
 | `image_path` | string | No | Path to image (e.g. `/local/images/trip.jpg`) |
 | `url` | string | No | Website or booking URL |
 | `memo` | string | No | Free-text notes (Markdown) |
@@ -481,7 +481,7 @@ async_step_user (menu)
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `target_date` | date | Yes | Target date |
-| `image_upload` | file | No | Upload image |
+| `image_upload` | file | No | Upload image (JPEG/PNG/WebP/GIF, max 5 MB) |
 | `image_path` | string | No | Path to image |
 | `url` | string | No | Website or related URL |
 | `memo` | string | No | Free-text notes (Markdown) |
@@ -801,6 +801,7 @@ gh release create vX.Y.Z --title "vX.Y.Z" --notes-file RELEASENOTES.md
 | 2.2.1 | 2025-02 | Special Events (holidays, DST), OptionsFlow fixes, removed astronomical events |
 | 2.3.0 | 2026-03 | FR08 Calendar entity, FR09 Custom Pattern, FR11 URL/Memo sensors, Bug 003 fixes |
 | 2.4.0 | 2026-05 | FR13 Expiry notifications via HA Repairs |
+| 2.4.1 | 2026-05 | Fix #12: Image upload validation (extension check, 5 MB size limit), options flow error translations |
 
 For detailed release notes with descriptions and issue links, see [`RELEASENOTES.md`](RELEASENOTES.md).
 

--- a/custom_components/whenhub/config_flow.py
+++ b/custom_components/whenhub/config_flow.py
@@ -87,44 +87,55 @@ _IMAGE_MIME_MAP = {
 }
 
 
-def _process_image_upload(hass: HomeAssistant, user_input: dict) -> tuple[str | None, str | None]:
+def _process_image_upload(hass: HomeAssistant, user_input: dict) -> tuple[str | None, str | None, str | None]:
     """Process an uploaded image file from a FileSelector field.
 
-    Returns (base64_data, mime_type) if an upload was provided, (None, None) otherwise.
+    Returns (base64_data, mime_type, error_key):
+    - (None, None, None): no upload provided
+    - (data, mime, None): upload successful
+    - (None, None, "image_upload_failed"): unsupported file type
     """
     upload_id = user_input.get(CONF_IMAGE_UPLOAD)
     if not upload_id:
-        return None, None
+        return None, None, None
     try:
         with process_uploaded_file(hass, upload_id) as path:
+            if path.suffix.lower() not in _IMAGE_MIME_MAP:
+                return None, None, "image_upload_failed"
             image_bytes = path.read_bytes()
             image_data = base64.b64encode(image_bytes).decode()
-            image_mime = _IMAGE_MIME_MAP.get(path.suffix.lower(), "image/jpeg")
-            return image_data, image_mime
+            image_mime = _IMAGE_MIME_MAP[path.suffix.lower()]
+            return image_data, image_mime, None
     except Exception as err:
         _LOGGER.warning("Failed to process uploaded image: %s", err)
-        return None, None
+        return None, None, None
 
 
-def _apply_image_changes(hass: HomeAssistant, new_data: dict, user_input: dict) -> None:
+def _apply_image_changes(hass: HomeAssistant, new_data: dict, user_input: dict) -> str | None:
     """Apply image upload / delete choices from user_input to new_data (in-place).
 
     - If 'image_delete' is checked: clears image_data, image_mime, image_path.
     - Else if a file was uploaded: stores base64 data and MIME type.
     - Else: leaves existing image_data / image_mime untouched.
     Always removes the temporary UI-only keys from new_data.
+    Returns an error key string if the uploaded file type is unsupported, None otherwise.
     """
     if user_input.get(CONF_IMAGE_DELETE):
         new_data["image_data"] = None
         new_data[CONF_IMAGE_MIME] = None
         new_data[CONF_IMAGE_PATH] = ""
     else:
-        image_data, image_mime = _process_image_upload(hass, user_input)
+        image_data, image_mime, error = _process_image_upload(hass, user_input)
+        if error:
+            new_data.pop(CONF_IMAGE_UPLOAD, None)
+            new_data.pop(CONF_IMAGE_DELETE, None)
+            return error
         if image_data:
             new_data["image_data"] = image_data
             new_data[CONF_IMAGE_MIME] = image_mime
     new_data.pop(CONF_IMAGE_UPLOAD, None)
     new_data.pop(CONF_IMAGE_DELETE, None)
+    return None
 
 
 def _schema_image(current: dict, show_delete: bool = False) -> dict:
@@ -513,12 +524,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if not errors:
             user_input[CONF_EVENT_TYPE] = self._event_type
-            image_data, image_mime = _process_image_upload(self.hass, user_input)
-            if image_data:
-                user_input["image_data"] = image_data
-                user_input[CONF_IMAGE_MIME] = image_mime
-            user_input.pop(CONF_IMAGE_UPLOAD, None)
-            return self.async_create_entry(title=self._suggest_event_name("Trip"), data=user_input)
+            image_data, image_mime, img_error = _process_image_upload(self.hass, user_input)
+            if img_error:
+                errors["base"] = img_error
+            else:
+                if image_data:
+                    user_input["image_data"] = image_data
+                    user_input[CONF_IMAGE_MIME] = image_mime
+                user_input.pop(CONF_IMAGE_UPLOAD, None)
+                return self.async_create_entry(title=self._suggest_event_name("Trip"), data=user_input)
 
         return await self._show_trip_form(user_input, errors)
 
@@ -549,7 +563,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self._show_milestone_form()
 
         user_input[CONF_EVENT_TYPE] = self._event_type
-        image_data, image_mime = _process_image_upload(self.hass, user_input)
+        image_data, image_mime, img_error = _process_image_upload(self.hass, user_input)
+        if img_error:
+            return await self._show_milestone_form(user_input, {"base": img_error})
         if image_data:
             user_input["image_data"] = image_data
             user_input[CONF_IMAGE_MIME] = image_mime
@@ -582,7 +598,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self._show_anniversary_form()
 
         user_input[CONF_EVENT_TYPE] = self._event_type
-        image_data, image_mime = _process_image_upload(self.hass, user_input)
+        image_data, image_mime, img_error = _process_image_upload(self.hass, user_input)
+        if img_error:
+            return await self._show_anniversary_form(user_input, {"base": img_error})
         if image_data:
             user_input["image_data"] = image_data
             user_input[CONF_IMAGE_MIME] = image_mime
@@ -649,7 +667,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         user_input[CONF_EVENT_TYPE] = self._event_type
         user_input[CONF_SPECIAL_CATEGORY] = self._special_category
-        image_data, image_mime = _process_image_upload(self.hass, user_input)
+        image_data, image_mime, img_error = _process_image_upload(self.hass, user_input)
+        if img_error:
+            return await self._show_special_event_form(user_input, {"base": img_error})
         if image_data:
             user_input["image_data"] = image_data
             user_input[CONF_IMAGE_MIME] = image_mime
@@ -699,7 +719,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         user_input[CONF_EVENT_TYPE] = self._event_type
         user_input[CONF_SPECIAL_CATEGORY] = self._special_category
-        image_data, image_mime = _process_image_upload(self.hass, user_input)
+        image_data, image_mime, img_error = _process_image_upload(self.hass, user_input)
+        if img_error:
+            return await self._show_dst_event_form(user_input, {"base": img_error})
         if image_data:
             user_input["image_data"] = image_data
             user_input[CONF_IMAGE_MIME] = image_mime
@@ -913,6 +935,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="cp_image",
                 data_schema=_schema_cp_image(self._cp_data),
             )
+        if user_input.get(CONF_IMAGE_UPLOAD):
+            _, _, img_error = _process_image_upload(self.hass, user_input)
+            if img_error:
+                return self.async_show_form(
+                    step_id="cp_image",
+                    data_schema=_schema_cp_image(self._cp_data),
+                    errors={"base": img_error},
+                )
         self._cp_data[CONF_IMAGE_PATH] = user_input.get(CONF_IMAGE_PATH, "")
         if user_input.get(CONF_IMAGE_UPLOAD):
             self._cp_data[CONF_IMAGE_UPLOAD] = user_input[CONF_IMAGE_UPLOAD]
@@ -922,7 +952,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _cp_create_entry(self) -> FlowResult:
         """Assemble entry data and create the config entry."""
-        image_data, image_mime = _process_image_upload(self.hass, self._cp_data)
+        image_data, image_mime, _ = _process_image_upload(self.hass, self._cp_data)
         data = {
             CONF_EVENT_TYPE: self._event_type,
             CONF_SPECIAL_CATEGORY: "custom_pattern",
@@ -1001,15 +1031,17 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
                 new_data = dict(self.config_entry.data)
                 new_data.update(user_input)
-                _apply_image_changes(self.hass, new_data, user_input)
+                img_error = _apply_image_changes(self.hass, new_data, user_input)
+                if img_error:
+                    errors["base"] = img_error
+                else:
+                    self.hass.config_entries.async_update_entry(
+                        self.config_entry,
+                        data=new_data,
+                    )
 
-                self.hass.config_entries.async_update_entry(
-                    self.config_entry,
-                    data=new_data,
-                )
-
-                self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
-                return self.async_create_entry(title="", data={})
+                    self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
+                    return self.async_create_entry(title="", data={})
 
         current_data = user_input if user_input is not None else self.config_entry.data
         has_image = bool(self.config_entry.data.get("image_data") or self.config_entry.data.get(CONF_IMAGE_PATH))
@@ -1031,20 +1063,23 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle milestone options."""
+        errors = {}
         if user_input is not None:
             user_input[CONF_EVENT_TYPE] = self.config_entry.data[CONF_EVENT_TYPE]
 
             new_data = dict(self.config_entry.data)
             new_data.update(user_input)
-            _apply_image_changes(self.hass, new_data, user_input)
+            img_error = _apply_image_changes(self.hass, new_data, user_input)
+            if img_error:
+                errors["base"] = img_error
+            else:
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data=new_data,
+                )
 
-            self.hass.config_entries.async_update_entry(
-                self.config_entry,
-                data=new_data,
-            )
-
-            self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
-            return self.async_create_entry(title="", data={})
+                self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
+                return self.async_create_entry(title="", data={})
 
         current_data = self.config_entry.data
         has_image = bool(current_data.get("image_data") or current_data.get(CONF_IMAGE_PATH))
@@ -1058,26 +1093,30 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="milestone_options",
             data_schema=data_schema,
+            errors=errors,
         )
 
     async def async_step_anniversary_options(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle anniversary options."""
+        errors = {}
         if user_input is not None:
             user_input[CONF_EVENT_TYPE] = self.config_entry.data[CONF_EVENT_TYPE]
 
             new_data = dict(self.config_entry.data)
             new_data.update(user_input)
-            _apply_image_changes(self.hass, new_data, user_input)
+            img_error = _apply_image_changes(self.hass, new_data, user_input)
+            if img_error:
+                errors["base"] = img_error
+            else:
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data=new_data,
+                )
 
-            self.hass.config_entries.async_update_entry(
-                self.config_entry,
-                data=new_data,
-            )
-
-            self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
-            return self.async_create_entry(title="", data={})
+                self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
+                return self.async_create_entry(title="", data={})
 
         current_data = self.config_entry.data
         has_image = bool(current_data.get("image_data") or current_data.get(CONF_IMAGE_PATH))
@@ -1090,26 +1129,30 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="anniversary_options",
             data_schema=data_schema,
+            errors=errors,
         )
 
     async def async_step_special_options(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle special event options."""
+        errors = {}
         if user_input is not None:
             user_input[CONF_EVENT_TYPE] = self.config_entry.data[CONF_EVENT_TYPE]
 
             new_data = dict(self.config_entry.data)
             new_data.update(user_input)
-            _apply_image_changes(self.hass, new_data, user_input)
+            img_error = _apply_image_changes(self.hass, new_data, user_input)
+            if img_error:
+                errors["base"] = img_error
+            else:
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data=new_data,
+                )
 
-            self.hass.config_entries.async_update_entry(
-                self.config_entry,
-                data=new_data,
-            )
-
-            self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
-            return self.async_create_entry(title="", data={})
+                self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
+                return self.async_create_entry(title="", data={})
 
         current_data = self.config_entry.data
 
@@ -1146,27 +1189,31 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="special_options",
             data_schema=data_schema,
+            errors=errors,
         )
 
     async def async_step_dst_options(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle DST event options."""
+        errors = {}
         if user_input is not None:
             user_input[CONF_EVENT_TYPE] = self.config_entry.data[CONF_EVENT_TYPE]
             user_input[CONF_SPECIAL_CATEGORY] = self.config_entry.data.get(CONF_SPECIAL_CATEGORY, "dst")
 
             new_data = dict(self.config_entry.data)
             new_data.update(user_input)
-            _apply_image_changes(self.hass, new_data, user_input)
+            img_error = _apply_image_changes(self.hass, new_data, user_input)
+            if img_error:
+                errors["base"] = img_error
+            else:
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data=new_data,
+                )
 
-            self.hass.config_entries.async_update_entry(
-                self.config_entry,
-                data=new_data,
-            )
-
-            self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
-            return self.async_create_entry(title="", data={})
+                self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
+                return self.async_create_entry(title="", data={})
 
         current_data = self.config_entry.data
         region_options = list(DST_REGIONS.keys())
@@ -1195,6 +1242,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="dst_options",
             data_schema=data_schema,
+            errors=errors,
         )
 
     async def async_step_calendar_options(
@@ -1456,6 +1504,19 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 step_id="cp_image",
                 data_schema=data_schema,
             )
+        if user_input.get(CONF_IMAGE_UPLOAD):
+            _, _, img_error = _process_image_upload(self.hass, user_input)
+            if img_error:
+                data_schema = _schema_cp_image(merged, show_delete=has_image) if not has_end else vol.Schema({
+                    **_schema_image(merged, show_delete=has_image),
+                    **_schema_url_memo(merged),
+                    **_schema_notify_on_expiry(merged),
+                })
+                return self.async_show_form(
+                    step_id="cp_image",
+                    data_schema=data_schema,
+                    errors={"base": img_error},
+                )
         self._cp_data[CONF_IMAGE_PATH] = user_input.get(CONF_IMAGE_PATH, "")
         if user_input.get(CONF_IMAGE_UPLOAD):
             self._cp_data[CONF_IMAGE_UPLOAD] = user_input[CONF_IMAGE_UPLOAD]
@@ -1476,7 +1537,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         # Ensure fixed keys are always present
         new_data[CONF_EVENT_TYPE] = self.config_entry.data[CONF_EVENT_TYPE]
         new_data[CONF_SPECIAL_CATEGORY] = "custom_pattern"
-        _apply_image_changes(self.hass, new_data, self._cp_data)
+        _apply_image_changes(self.hass, new_data, self._cp_data)  # upload already validated in async_step_cp_image
 
         self.hass.config_entries.async_update_entry(
             self.config_entry,

--- a/custom_components/whenhub/config_flow.py
+++ b/custom_components/whenhub/config_flow.py
@@ -86,6 +86,9 @@ _IMAGE_MIME_MAP = {
     ".gif": "image/gif",
 }
 
+# Maximum allowed image file size (5 MB). Larger files would bloat the config entry JSON.
+_MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024
+
 
 def _process_image_upload(hass: HomeAssistant, user_input: dict) -> tuple[str | None, str | None, str | None]:
     """Process an uploaded image file from a FileSelector field.
@@ -94,6 +97,7 @@ def _process_image_upload(hass: HomeAssistant, user_input: dict) -> tuple[str | 
     - (None, None, None): no upload provided
     - (data, mime, None): upload successful
     - (None, None, "image_upload_failed"): unsupported file type
+    - (None, None, "image_too_large"): file exceeds _MAX_IMAGE_SIZE_BYTES
     """
     upload_id = user_input.get(CONF_IMAGE_UPLOAD)
     if not upload_id:
@@ -102,6 +106,8 @@ def _process_image_upload(hass: HomeAssistant, user_input: dict) -> tuple[str | 
         with process_uploaded_file(hass, upload_id) as path:
             if path.suffix.lower() not in _IMAGE_MIME_MAP:
                 return None, None, "image_upload_failed"
+            if path.stat().st_size > _MAX_IMAGE_SIZE_BYTES:
+                return None, None, "image_too_large"
             image_bytes = path.read_bytes()
             image_data = base64.b64encode(image_bytes).decode()
             image_mime = _IMAGE_MIME_MAP[path.suffix.lower()]

--- a/custom_components/whenhub/translations/de.json
+++ b/custom_components/whenhub/translations/de.json
@@ -223,7 +223,8 @@
     "error": {
       "invalid_dates": "Das Enddatum muss nach dem Startdatum liegen",
       "invalid_date_format": "Ungültiges Datumsformat. Verwende YYYY-MM-DD",
-      "image_upload_failed": "Fehler beim Hochladen des Bildes"
+      "image_upload_failed": "Nicht unterstütztes Dateiformat. Bitte lade eine JPEG-, PNG-, WebP- oder GIF-Datei hoch.",
+      "image_too_large": "Die Datei ist zu groß. Die maximale Dateigröße beträgt 5 MB."
     }
   },
   "options": {
@@ -430,6 +431,12 @@
           "notify_on_expiry": "Erstellt eine Meldung in HA-Reparaturen, wenn dieses Muster keine zukünftigen Vorkommen mehr hat"
         }
       }
+    },
+    "error": {
+      "invalid_dates": "Das Enddatum muss nach dem Startdatum liegen",
+      "invalid_date_format": "Ungültiges Datumsformat. Verwende YYYY-MM-DD",
+      "image_upload_failed": "Nicht unterstütztes Dateiformat. Bitte lade eine JPEG-, PNG-, WebP- oder GIF-Datei hoch.",
+      "image_too_large": "Die Datei ist zu groß. Die maximale Dateigröße beträgt 5 MB."
     }
   },
   "selector": {

--- a/custom_components/whenhub/translations/en.json
+++ b/custom_components/whenhub/translations/en.json
@@ -223,7 +223,8 @@
     "error": {
       "invalid_dates": "End date must be after start date",
       "invalid_date_format": "Invalid date format. Use YYYY-MM-DD",
-      "image_upload_failed": "Error uploading image"
+      "image_upload_failed": "Unsupported file type. Please upload a JPEG, PNG, WebP or GIF file.",
+      "image_too_large": "File is too large. Maximum allowed size is 5 MB."
     }
   },
   "options": {
@@ -430,6 +431,12 @@
           "notify_on_expiry": "Create a notification in HA Repairs when this repeating event has no more future occurrences"
         }
       }
+    },
+    "error": {
+      "invalid_dates": "End date must be after start date",
+      "invalid_date_format": "Invalid date format. Use YYYY-MM-DD",
+      "image_upload_failed": "Unsupported file type. Please upload a JPEG, PNG, WebP or GIF file.",
+      "image_too_large": "File is too large. Maximum allowed size is 5 MB."
     }
   },
   "selector": {

--- a/tests/test_image_upload_validation.py
+++ b/tests/test_image_upload_validation.py
@@ -1,0 +1,247 @@
+"""Tests for image upload file-type validation (fix for issue #12).
+
+Tests _process_image_upload and _apply_image_changes to verify that
+unsupported file extensions are rejected with 'image_upload_failed'.
+"""
+from __future__ import annotations
+
+import sys
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch, mock_open
+from contextlib import contextmanager
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from custom_components.whenhub.config_flow import (
+    _process_image_upload,
+    _apply_image_changes,
+)
+from custom_components.whenhub.const import CONF_IMAGE_UPLOAD, CONF_IMAGE_DELETE, CONF_IMAGE_MIME
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_hass():
+    return MagicMock()
+
+
+def _mock_upload(suffix: str, content: bytes = b"fake_image_data"):
+    """Context manager that simulates process_uploaded_file returning a path."""
+    fake_path = MagicMock(spec=Path)
+    fake_path.suffix = suffix
+    fake_path.read_bytes.return_value = content
+
+    @contextmanager
+    def _ctx(hass, upload_id):
+        yield fake_path
+
+    return patch(
+        "custom_components.whenhub.config_flow.process_uploaded_file",
+        side_effect=_ctx,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _process_image_upload
+# ---------------------------------------------------------------------------
+
+class TestProcessImageUpload:
+    """Unit tests for _process_image_upload()."""
+
+    def test_no_upload_returns_triple_none(self):
+        """When no upload_id is in user_input, return (None, None, None)."""
+        result = _process_image_upload(_fake_hass(), {})
+        assert result == (None, None, None)
+
+    def test_no_upload_key_missing(self):
+        """Missing CONF_IMAGE_UPLOAD key → (None, None, None)."""
+        result = _process_image_upload(_fake_hass(), {"other_key": "value"})
+        assert result == (None, None, None)
+
+    def test_valid_jpg_accepted(self):
+        """JPEG file upload returns (base64_data, 'image/jpeg', None)."""
+        with _mock_upload(".jpg", b"jpeg_bytes"):
+            data, mime, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert data is not None
+        assert mime == "image/jpeg"
+        assert error is None
+
+    def test_valid_jpeg_accepted(self):
+        """.jpeg extension also maps to image/jpeg."""
+        with _mock_upload(".jpeg"):
+            data, mime, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert mime == "image/jpeg"
+        assert error is None
+
+    def test_valid_png_accepted(self):
+        """.png returns image/png."""
+        with _mock_upload(".png"):
+            data, mime, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert mime == "image/png"
+        assert error is None
+
+    def test_valid_webp_accepted(self):
+        """.webp returns image/webp."""
+        with _mock_upload(".webp"):
+            data, mime, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert mime == "image/webp"
+        assert error is None
+
+    def test_valid_gif_accepted(self):
+        """.gif returns image/gif."""
+        with _mock_upload(".gif"):
+            data, mime, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert mime == "image/gif"
+        assert error is None
+
+    def test_pdf_rejected(self):
+        """PDF files return (None, None, 'image_upload_failed')."""
+        with _mock_upload(".pdf"):
+            data, mime, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert data is None
+        assert mime is None
+        assert error == "image_upload_failed"
+
+    def test_exe_rejected(self):
+        """Executable files return error."""
+        with _mock_upload(".exe"):
+            data, mime, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert error == "image_upload_failed"
+
+    def test_txt_rejected(self):
+        """Text files return error."""
+        with _mock_upload(".txt"):
+            _, _, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert error == "image_upload_failed"
+
+    def test_no_extension_rejected(self):
+        """Files without extension return error."""
+        with _mock_upload(""):
+            _, _, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert error == "image_upload_failed"
+
+    def test_uppercase_extension_accepted(self):
+        """Extension check is case-insensitive (.JPG should be accepted)."""
+        with _mock_upload(".JPG"):
+            data, mime, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert error is None
+        assert mime == "image/jpeg"
+
+    def test_base64_data_is_returned(self):
+        """Successful upload returns base64-encoded content."""
+        import base64
+        content = b"hello image bytes"
+        with _mock_upload(".png", content):
+            data, mime, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert data == base64.b64encode(content).decode()
+
+    def test_exception_returns_triple_none(self):
+        """If process_uploaded_file raises, return (None, None, None) — not an error."""
+        with patch(
+            "custom_components.whenhub.config_flow.process_uploaded_file",
+            side_effect=OSError("disk error"),
+        ):
+            result = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert result == (None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# _apply_image_changes
+# ---------------------------------------------------------------------------
+
+class TestApplyImageChanges:
+    """Unit tests for _apply_image_changes()."""
+
+    def test_no_upload_returns_none(self):
+        """No upload provided → no error, new_data unchanged."""
+        new_data = {}
+        error = _apply_image_changes(_fake_hass(), new_data, {})
+        assert error is None
+
+    def test_valid_upload_stores_data(self):
+        """Valid upload stores image_data and image_mime, returns None."""
+        new_data = {}
+        with _mock_upload(".jpg", b"img"):
+            error = _apply_image_changes(
+                _fake_hass(), new_data, {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert error is None
+        assert "image_data" in new_data
+        assert new_data[CONF_IMAGE_MIME] == "image/jpeg"
+
+    def test_invalid_upload_returns_error_key(self):
+        """Invalid file type → returns 'image_upload_failed', does not store data."""
+        new_data = {}
+        with _mock_upload(".pdf"):
+            error = _apply_image_changes(
+                _fake_hass(), new_data, {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert error == "image_upload_failed"
+        assert "image_data" not in new_data
+
+    def test_invalid_upload_does_not_corrupt_existing_image(self):
+        """When validation fails, existing image_data is NOT overwritten."""
+        new_data = {"image_data": "old_data", CONF_IMAGE_MIME: "image/png"}
+        with _mock_upload(".exe"):
+            error = _apply_image_changes(
+                _fake_hass(), new_data, {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert error == "image_upload_failed"
+        assert new_data["image_data"] == "old_data"
+
+    def test_image_delete_clears_data(self):
+        """CONF_IMAGE_DELETE flag clears existing image, returns None."""
+        new_data = {"image_data": "some_data", CONF_IMAGE_MIME: "image/jpg"}
+        error = _apply_image_changes(
+            _fake_hass(), new_data, {CONF_IMAGE_DELETE: True}
+        )
+        assert error is None
+        assert new_data["image_data"] is None
+        assert new_data[CONF_IMAGE_MIME] is None
+
+    def test_upload_key_removed_from_new_data(self):
+        """CONF_IMAGE_UPLOAD key is always removed from new_data."""
+        new_data = {CONF_IMAGE_UPLOAD: "some_id"}
+        with _mock_upload(".png"):
+            _apply_image_changes(
+                _fake_hass(), new_data, {CONF_IMAGE_UPLOAD: "some_id"}
+            )
+        assert CONF_IMAGE_UPLOAD not in new_data
+
+    def test_upload_key_removed_even_on_error(self):
+        """CONF_IMAGE_UPLOAD is removed from new_data even when validation fails."""
+        new_data = {CONF_IMAGE_UPLOAD: "some_id"}
+        with _mock_upload(".pdf"):
+            _apply_image_changes(
+                _fake_hass(), new_data, {CONF_IMAGE_UPLOAD: "some_id"}
+            )
+        assert CONF_IMAGE_UPLOAD not in new_data

--- a/tests/test_image_upload_validation.py
+++ b/tests/test_image_upload_validation.py
@@ -30,11 +30,13 @@ def _fake_hass():
     return MagicMock()
 
 
-def _mock_upload(suffix: str, content: bytes = b"fake_image_data"):
+def _mock_upload(suffix: str, content: bytes = b"fake_image_data", size: int | None = None):
     """Context manager that simulates process_uploaded_file returning a path."""
     fake_path = MagicMock(spec=Path)
     fake_path.suffix = suffix
     fake_path.read_bytes.return_value = content
+    # Default size: len(content) — small enough to pass the 5 MB limit
+    fake_path.stat.return_value.st_size = size if size is not None else len(content)
 
     @contextmanager
     def _ctx(hass, upload_id):
@@ -161,6 +163,54 @@ class TestProcessImageUpload:
                 _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
             )
         assert data == base64.b64encode(content).decode()
+
+    def test_file_too_large_rejected(self):
+        """Files exceeding 5 MB return 'image_too_large' error."""
+        from custom_components.whenhub.config_flow import _MAX_IMAGE_SIZE_BYTES
+
+        fake_path = MagicMock(spec=Path)
+        fake_path.suffix = ".jpg"
+        fake_path.stat.return_value.st_size = _MAX_IMAGE_SIZE_BYTES + 1
+
+        @contextmanager
+        def _ctx(hass, upload_id):
+            yield fake_path
+
+        with patch(
+            "custom_components.whenhub.config_flow.process_uploaded_file",
+            side_effect=_ctx,
+        ):
+            data, mime, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert data is None
+        assert mime is None
+        assert error == "image_too_large"
+
+    def test_file_exactly_at_limit_accepted(self):
+        """File exactly at 5 MB limit is accepted."""
+        from custom_components.whenhub.config_flow import _MAX_IMAGE_SIZE_BYTES
+        import base64
+
+        content = b"x" * _MAX_IMAGE_SIZE_BYTES
+        fake_path = MagicMock(spec=Path)
+        fake_path.suffix = ".png"
+        fake_path.stat.return_value.st_size = _MAX_IMAGE_SIZE_BYTES
+        fake_path.read_bytes.return_value = content
+
+        @contextmanager
+        def _ctx(hass, upload_id):
+            yield fake_path
+
+        with patch(
+            "custom_components.whenhub.config_flow.process_uploaded_file",
+            side_effect=_ctx,
+        ):
+            data, mime, error = _process_image_upload(
+                _fake_hass(), {CONF_IMAGE_UPLOAD: "upload123"}
+            )
+        assert error is None
+        assert mime == "image/png"
 
     def test_exception_returns_triple_none(self):
         """If process_uploaded_file raises, return (None, None, None) — not an error."""


### PR DESCRIPTION
## Summary

- Server-side validation of uploaded images: only JPEG, PNG, WebP, GIF are accepted — other file types (PDF, EXE, etc.) return a clear error message
- File size limit of 5 MB enforced before reading bytes into memory
- Fixed missing `options.error` translation section — OptionsFlow was displaying raw error keys instead of translated messages
- Improved error message text (descriptive, multilingual EN + DE)

## Changes

- `config_flow.py`: `_MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024` constant; size check in `_process_image_upload()`
- `translations/en.json` + `de.json`: `options.error` section added; `image_too_large` key added; improved `image_upload_failed` text
- `README.md` + `TECHNICAL_REFERENCE.md`: upload limits documented, corrected image storage description (base64 in entry data, not www/)
- `tests/test_image_upload_validation.py`: extended with size limit tests (548 tests total, all passing)

## Test plan

- [x] Valid image types (JPG, PNG, WebP, GIF) accepted
- [x] Invalid types (PDF, EXE, TXT, no extension) rejected with translated error
- [x] File exactly at 5 MB limit accepted
- [x] File over 5 MB rejected with `image_too_large` error
- [x] OptionsFlow shows translated error (not raw key)
- [x] Existing image not overwritten on failed upload
- [x] 548 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)