### PR TITLE
Fix #14: standardize entity IDs to English type keys (v3.0.0 breaking change)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,109 +1,46 @@
 ### ✨ New Features
 
-- **WhenHub Calendar**
-  - All your WhenHub events are now available as a native Home Assistant calendar — visible in the calendar card and queryable in automations
-  - Create multiple independent calendars with different scopes: show everything, filter by event type (e.g. only Trips), or pick individual entries
-
-- **Repeating Events**
-  - New event type for anything that follows a regular pattern: weekly team meetings, monthly bill reminders, annual traditions
-  - Choose from daily, weekly (select individual weekdays), monthly, or yearly; optionally set an end date or a maximum occurrence count
-
-- **Event Images**
-  - Give every event its own image — drag and drop a photo directly in the setup dialog
-  - The image appears as a dedicated entity in the image platform, ready to use on dashboards
-
-- **URL and Memo**
-  - Attach a booking link or free-text notes to any event — useful for holidays, trips, or project milestones
-  - Both appear as Home Assistant sensors the moment the field is filled in, making them available to automations and companion apps
+- **Expiry Notifications** ([#13](https://github.com/moerk-o/WhenHub/issues/13))
+  - Trip, Milestone, and Custom Pattern events can now notify you when they expire
+  - An actionable issue appears in **Settings → System → Repairs** with a one-click removal flow
+  - Enable per event via the "Notify when expired" toggle (off by default)
+  - Auto-resolves if you update the event dates so it is no longer expired
 
 ### 🐞 Bug Fixes
 
-- **Cleaner Setup Flow**: The event name field no longer appears twice; WhenHub now generates a sensible title automatically and increments it if a duplicate already exists (e.g. "Trip 2")
-- **Next Date Sensor**: Fixed an off-by-one where the "next date" showed today on days the pattern fires, instead of pointing to the following occurrence
+- **Image upload validation** ([#12](https://github.com/moerk-o/WhenHub/issues/12))
+  - Uploaded files are now validated server-side: only JPEG, PNG, WebP and GIF are accepted
+  - Files larger than 5 MB are rejected with a clear error message
+  - Options flow now shows translated error messages (previously displayed raw error keys)
 
-**Full Changelog**: https://github.com/moerk-o/WhenHub/compare/v2.2.2...v2.3.0
+### ⚠️ Breaking Changes
 
----
+- **Entity IDs are now standardized to English keys** ([#14](https://github.com/moerk-o/WhenHub/issues/14))
 
-# v2.2.2
+  **All entity IDs are automatically renamed on first startup after the update.** No manual action is required for the migration itself, but you must update any references in dashboards, automations, and scripts before or after the update.
 
-### 🐞 Bug Fixes
+  Entity IDs now always use the internal English type key as their suffix, regardless of the Home Assistant system language. Previously, entity IDs were generated from the translated display name — causing them to differ between language settings.
 
-- **Binary Sensor Display Fixed**: Binary sensors now show "On/Off"
+  **Affected suffixes (all installations):**
 
-- **DST Default Name Localization**: Removed hardcoded German default names for DST events
+  | Old suffix | New suffix |
+  |---|---|
+  | `days_until_start` | `days_until` |
+  | `trip_days_remaining` | `trip_left_days` |
+  | `trip_percent_remaining` | `trip_left_percent` |
+  | `daylight_saving_time_active` | `is_dst_active` |
 
-**Full Changelog**: https://github.com/moerk-o/WhenHub/compare/v2.2.1...v2.2.2
+  **Additional suffixes affected on non-English Home Assistant installations** (e.g. German): all entity ID suffixes were previously in the system language and are now standardized to English.
 
----
-
-# v2.2.1
-
-### ✨ New Features
-
-- **Language-based Entity IDs**
-  - Entity IDs now based on configured HA language
-  - Correct translations for sensor names in DE/EN
-  - `EntityDescription` for consistent naming
-
-- **Improved Date Picker**
-  - Native Home Assistant `DateSelector` for date selection
-  - Better UX in Config Flow
-
-### 🐞 Bug Fixes
-- **OptionsFlow Error Fixed**: 500 Internal Server Error when clicking "Configure" in newer Home Assistant versions
-  - Cause: `config_entry` is a read-only property of `OptionsFlow` base class in newer HA versions
-  - Fix: Removed `__init__` method from `OptionsFlowHandler`
-- **DSTBinarySensor Icon Bug**: Fixed `AttributeError` when accessing `_attr_icon`
-- **Options Flow Error Display**: Validation errors are now displayed correctly
-
-### 🔧 Infrastructure
-- **Device Info Cleanup**: Removed firmware version from device info (WhenHub events are virtual devices without actual firmware)
-- **HACS ZIP Release**: Enabled `zip_release` 
+  **Example (German installation):**
+  - Before: `sensor.johns_geburtstag_ereignisdatum`
+  - After: `sensor.johns_geburtstag_event_date`
 
 ### 📝 Documentation
-- Added GitHub repository description and topics
 
-### 🗑️ Removed
-- **Astronomical Events Removed**
-  - Sunrise, sunset, solstice, equinox removed
-  - These are better covered by dedicated integrations (e.g., [Solstice Season](https://github.com/moerk-o/ha-solstice_season) for precise seasonal data or HA Core [Sun](https://www.home-assistant.io/integrations/sun/))
+- Updated README and Technical Reference with upload limits, corrected image storage description, and migration details
+- For the complete v2.x.x release history, see [RELEASENOTES_v2.md](RELEASENOTES_v2.md)
 
-**Full Changelog**: https://github.com/moerk-o/WhenHub/compare/v2.2.0...v2.2.1
+**Full Changelog**: https://github.com/moerk-o/WhenHub/compare/v2.3.0...v3.0.0
 
 ---
-
-# v2.2.0 (internal)
-
-*This version was released but superseded by v2.2.1. Changes are included above.*
-
----
-
-# v2.1.0 (internal)
-
-*This version was not released publicly. Changes are included in v2.2.1.*
-
----
-
-# v2.0.0
-
-### ✨ New Features
-- **Internationalization**
-  - Full German and English support
-  - UI automatically adapts to your Home Assistant language setting
-
-- **Localized Date Display**
-  - Date sensors now show relative time in the frontend ("In 18 days", "Tomorrow")
-  - Use `format: relative`, `format: date`, etc. in Lovelace cards
-
-- **Improved Sensor Classes**
-  - `device_class: timestamp` for all date sensors
-  - `device_class: duration` with unit "d" for all days sensors
-
-### 📝 Documentation
-- Updated README with new features documentation
-
-### 🔧 Infrastructure
-- Code cleanup and improved type hints
-
-**Full Changelog**: https://github.com/moerk-o/WhenHub/compare/v1.0.0...v2.0.0

--- a/RELEASENOTES_v2.md
+++ b/RELEASENOTES_v2.md
@@ -1,0 +1,111 @@
+# v2.3.0
+
+### ✨ New Features
+
+- **WhenHub Calendar**
+  - All your WhenHub events are now available as a native Home Assistant calendar — visible in the calendar card and queryable in automations
+  - Create multiple independent calendars with different scopes: show everything, filter by event type (e.g. only Trips), or pick individual entries
+
+- **Repeating Events**
+  - New event type for anything that follows a regular pattern: weekly team meetings, monthly bill reminders, annual traditions
+  - Choose from daily, weekly (select individual weekdays), monthly, or yearly; optionally set an end date or a maximum occurrence count
+
+- **Event Images**
+  - Give every event its own image — drag and drop a photo directly in the setup dialog
+  - The image appears as a dedicated entity in the image platform, ready to use on dashboards
+
+- **URL and Memo**
+  - Attach a booking link or free-text notes to any event — useful for holidays, trips, or project milestones
+  - Both appear as Home Assistant sensors the moment the field is filled in, making them available to automations and companion apps
+
+### 🐞 Bug Fixes
+
+- **Cleaner Setup Flow**: The event name field no longer appears twice; WhenHub now generates a sensible title automatically and increments it if a duplicate already exists (e.g. "Trip 2")
+- **Next Date Sensor**: Fixed an off-by-one where the "next date" showed today on days the pattern fires, instead of pointing to the following occurrence
+
+**Full Changelog**: https://github.com/moerk-o/WhenHub/compare/v2.2.2...v2.3.0
+
+---
+
+# v2.2.2
+
+### 🐞 Bug Fixes
+
+- **Binary Sensor Display Fixed**: Binary sensors now show "On/Off"
+
+- **DST Default Name Localization**: Removed hardcoded German default names for DST events
+
+**Full Changelog**: https://github.com/moerk-o/WhenHub/compare/v2.2.1...v2.2.2
+
+---
+
+# v2.2.1
+
+### ✨ New Features
+
+- **Language-based Entity IDs**
+  - Entity IDs now based on configured HA language
+  - Correct translations for sensor names in DE/EN
+  - `EntityDescription` for consistent naming
+
+- **Improved Date Picker**
+  - Native Home Assistant `DateSelector` for date selection
+  - Better UX in Config Flow
+
+### 🐞 Bug Fixes
+- **OptionsFlow Error Fixed**: 500 Internal Server Error when clicking "Configure" in newer Home Assistant versions
+  - Cause: `config_entry` is a read-only property of `OptionsFlow` base class in newer HA versions
+  - Fix: Removed `__init__` method from `OptionsFlowHandler`
+- **DSTBinarySensor Icon Bug**: Fixed `AttributeError` when accessing `_attr_icon`
+- **Options Flow Error Display**: Validation errors are now displayed correctly
+
+### 🔧 Infrastructure
+- **Device Info Cleanup**: Removed firmware version from device info (WhenHub events are virtual devices without actual firmware)
+- **HACS ZIP Release**: Enabled `zip_release` 
+
+### 📝 Documentation
+- Added GitHub repository description and topics
+
+### 🗑️ Removed
+- **Astronomical Events Removed**
+  - Sunrise, sunset, solstice, equinox removed
+  - These are better covered by dedicated integrations (e.g., [Solstice Season](https://github.com/moerk-o/ha-solstice_season) for precise seasonal data or HA Core [Sun](https://www.home-assistant.io/integrations/sun/))
+
+**Full Changelog**: https://github.com/moerk-o/WhenHub/compare/v2.2.0...v2.2.1
+
+---
+
+# v2.2.0 (internal)
+
+*This version was released but superseded by v2.2.1. Changes are included above.*
+
+---
+
+# v2.1.0 (internal)
+
+*This version was not released publicly. Changes are included in v2.2.1.*
+
+---
+
+# v2.0.0
+
+### ✨ New Features
+- **Internationalization**
+  - Full German and English support
+  - UI automatically adapts to your Home Assistant language setting
+
+- **Localized Date Display**
+  - Date sensors now show relative time in the frontend ("In 18 days", "Tomorrow")
+  - Use `format: relative`, `format: date`, etc. in Lovelace cards
+
+- **Improved Sensor Classes**
+  - `device_class: timestamp` for all date sensors
+  - `device_class: duration` with unit "d" for all days sensors
+
+### 📝 Documentation
+- Updated README with new features documentation
+
+### 🔧 Infrastructure
+- Code cleanup and improved type hints
+
+**Full Changelog**: https://github.com/moerk-o/WhenHub/compare/v1.0.0...v2.0.0

--- a/TECHNICAL_REFERENCE.md
+++ b/TECHNICAL_REFERENCE.md
@@ -41,6 +41,7 @@ WhenHub provides:
 
 - **Domain:** `whenhub`
 - **Entity Prefix:** User-defined event name (e.g., "Denmark Vacation" → `sensor.denmark_vacation_*`)
+- **Entity ID Suffix:** Always the English sensor type key, regardless of HA system language (e.g., `days_until`, not `tage_bis_start`). Enforced via `suggested_object_id` since v3.0.0.
 - **Unique ID Pattern:** `{entry_id}_{sensor_type}`
 
 ---
@@ -802,6 +803,7 @@ gh release create vX.Y.Z --title "vX.Y.Z" --notes-file RELEASENOTES.md
 | 2.3.0 | 2026-03 | FR08 Calendar entity, FR09 Custom Pattern, FR11 URL/Memo sensors, Bug 003 fixes |
 | 2.4.0 | 2026-05 | FR13 Expiry notifications via HA Repairs |
 | 2.4.1 | 2026-05 | Fix #12: Image upload validation (extension check, 5 MB size limit), options flow error translations |
+| 3.0.0 | 2026-05 | FR13 Expiry notifications (HA Repairs), Fix #12 image validation, Fix #14 entity ID standardization (English type keys, automatic migration v1→v2) |
 
 For detailed release notes with descriptions and issue links, see [`RELEASENOTES.md`](RELEASENOTES.md).
 

--- a/custom_components/whenhub/__init__.py
+++ b/custom_components/whenhub/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
 
 from .const import DOMAIN, CONF_ENTRY_TYPE, ENTRY_TYPE_CALENDAR
 from .coordinator import WhenHubCoordinator
@@ -22,6 +23,83 @@ _LOGGER = logging.getLogger(__name__)
 # Platforms per entry type
 EVENT_PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.IMAGE, Platform.BINARY_SENSOR]
 CALENDAR_PLATFORMS: list[Platform] = [Platform.CALENDAR]
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate config entry to the current version.
+
+    Version 1 → 2 (v3.0.0): Standardize entity IDs to English type-key suffixes.
+
+    Entity IDs were previously generated from the translated entity name (language-
+    dependent). This migration renames them to always use the English sensor type key
+    (e.g. 'event_date' instead of 'ereignisdatum' on German HA).
+    Also affects English installs where the translated name differed from the type
+    key (e.g. 'days_until_start' → 'days_until', 'trip_days_remaining' → 'trip_left_days').
+    """
+    _LOGGER.info("Migrating WhenHub entry '%s' from version %s to 2", entry.title, entry.version)
+
+    if entry.version == 1:
+        # Calendar entries have no sensor entities with language-dependent IDs.
+        if entry.data.get(CONF_ENTRY_TYPE) == ENTRY_TYPE_CALENDAR:
+            hass.config_entries.async_update_entry(entry, version=2)
+            return True
+
+        entity_registry = er.async_get(hass)
+        entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        device_slug = slugify(entry.title)
+        entry_id = entry.entry_id
+        binary_prefix = f"{entry_id}_binary_"
+        entry_prefix = f"{entry_id}_"
+        renamed = 0
+
+        for entity_entry in entities:
+            uid = entity_entry.unique_id
+            platform = entity_entry.domain  # "sensor", "binary_sensor", or "image"
+
+            # Determine the canonical English suffix from the unique_id
+            if uid == f"{entry_id}_image":
+                english_suffix = "event_image"
+            elif uid == f"{entry_id}_calendar":
+                continue  # Should not occur for event entries, skip to be safe
+            elif uid.startswith(binary_prefix):
+                english_suffix = uid[len(binary_prefix):]
+            elif uid.startswith(entry_prefix):
+                english_suffix = uid[len(entry_prefix):]
+            else:
+                _LOGGER.warning("Unexpected unique_id during migration: %s — skipping", uid)
+                continue
+
+            expected_entity_id = f"{platform}.{device_slug}_{english_suffix}"
+
+            if entity_entry.entity_id == expected_entity_id:
+                continue  # Already correct (no rename needed)
+
+            # Skip if the target entity_id is already taken by another entity
+            if entity_registry.async_get(expected_entity_id) is not None:
+                _LOGGER.warning(
+                    "Cannot rename %s → %s: target already exists. "
+                    "Please rename manually.",
+                    entity_entry.entity_id,
+                    expected_entity_id,
+                )
+                continue
+
+            entity_registry.async_update_entity(
+                entity_entry.entity_id,
+                new_entity_id=expected_entity_id,
+            )
+            _LOGGER.debug("Renamed entity: %s → %s", entity_entry.entity_id, expected_entity_id)
+            renamed += 1
+
+        hass.config_entries.async_update_entry(entry, version=2)
+        _LOGGER.info(
+            "Migration complete for '%s': %d of %d entities renamed",
+            entry.title,
+            renamed,
+            len(entities),
+        )
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/whenhub/binary_sensor.py
+++ b/custom_components/whenhub/binary_sensor.py
@@ -194,6 +194,15 @@ class BaseBinarySensor(CoordinatorEntity["WhenHubCoordinator"], BinarySensorEnti
         )
 
     @property
+    def suggested_object_id(self) -> str:
+        """Return the English sensor type key as the entity ID suffix.
+
+        Ensures entity IDs are language-independent (e.g. always 'is_today',
+        never 'ist_heute'). See BaseSensor.suggested_object_id for details.
+        """
+        return self._sensor_type
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return device information about this entity.
 

--- a/custom_components/whenhub/config_flow.py
+++ b/custom_components/whenhub/config_flow.py
@@ -332,7 +332,7 @@ def _schema_cp_image(current: dict, show_delete: bool = False) -> vol.Schema:
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for WhenHub."""
 
-    VERSION = 1
+    VERSION = 2  # v3.0.0: entity IDs standardized to English keys (migration in async_migrate_entry)
 
     def __init__(self) -> None:
         """Initialize the config flow."""

--- a/custom_components/whenhub/image.py
+++ b/custom_components/whenhub/image.py
@@ -94,9 +94,14 @@ class WhenHubImage(ImageEntity):
         self._image_mime = event_data.get(CONF_IMAGE_MIME)  # Stored MIME type for uploads
 
     @property
+    def suggested_object_id(self) -> str:
+        """Return fixed English key as entity ID suffix (language-independent)."""
+        return "event_image"
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return device information about this entity.
-        
+
         Groups this image entity with other entities from the same WhenHub event.
         """
         return get_device_info(self._config_entry, self._event_data)

--- a/custom_components/whenhub/sensors/base.py
+++ b/custom_components/whenhub/sensors/base.py
@@ -147,6 +147,17 @@ class BaseSensor(CoordinatorEntity["WhenHubCoordinator"], SensorEntity):
         self._attr_unique_id = f"{config_entry.entry_id}_{sensor_type}"
 
     @property
+    def suggested_object_id(self) -> str:
+        """Return the English sensor type key as the entity ID suffix.
+
+        Ensures entity IDs are always language-independent regardless of the HA
+        system language (e.g. always 'event_date', never 'ereignisdatum').
+        Only takes effect for newly created entities; existing IDs are migrated
+        via async_migrate_entry when upgrading from config entry version 1 to 2.
+        """
+        return self._sensor_type
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return device information about this entity.
 

--- a/custom_components/whenhub/sensors/url_memo.py
+++ b/custom_components/whenhub/sensors/url_memo.py
@@ -36,6 +36,11 @@ class WhenHubUrlSensor(CoordinatorEntity["WhenHubCoordinator"], SensorEntity):
         self._attr_unique_id = f"{config_entry.entry_id}_url"
 
     @property
+    def suggested_object_id(self) -> str:
+        """Return fixed English key as entity ID suffix (language-independent)."""
+        return "url"
+
+    @property
     def device_info(self) -> DeviceInfo:
         return get_device_info(self._config_entry, self._event_data)
 
@@ -65,6 +70,11 @@ class WhenHubMemoSensor(CoordinatorEntity["WhenHubCoordinator"], SensorEntity):
         self._config_entry = config_entry
         self._event_data = event_data
         self._attr_unique_id = f"{config_entry.entry_id}_memo"
+
+    @property
+    def suggested_object_id(self) -> str:
+        """Return fixed English key as entity ID suffix (language-independent)."""
+        return "memo"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/tests/test_custom_pattern_integration.py
+++ b/tests/test_custom_pattern_integration.py
@@ -441,8 +441,8 @@ class TestCustomPatternSensors:
         await hass.async_block_till_done()
 
         assert entry.state == ConfigEntryState.LOADED
-        # days_until translates to "Days until start" → entity_id ends with days_until_start
-        state = hass.states.get("sensor.every_day_days_until_start")
+        # days_until translates to "Days until start" → entity_id ends with days_until
+        state = hass.states.get("sensor.every_day_days_until")
         assert state is not None
         # Today IS an occurrence → days_until shows days to NEXT future occurrence = 1
         assert state.state == "1"
@@ -460,7 +460,7 @@ class TestCustomPatternSensors:
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        state = hass.states.get("sensor.mon_wed_days_until_start")
+        state = hass.states.get("sensor.mon_wed_days_until")
         assert state is not None
         # Monday IS occurrence → next_display = Wed Apr 8 → days_until == 2
         assert state.state == "2"
@@ -520,7 +520,7 @@ class TestCustomPatternSensors:
         assert bs is not None
         assert bs.state == "on"
         # days_until shows days to next Thanksgiving (2027-11-25 = 364 days away)
-        state = hass.states.get("sensor.thanksgiving_days_until_start")
+        state = hass.states.get("sensor.thanksgiving_days_until")
         assert state is not None
         assert state.state == "364"
 
@@ -537,7 +537,7 @@ class TestCustomPatternSensors:
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        state = hass.states.get("sensor.thanksgiving_future_days_until_start")
+        state = hass.states.get("sensor.thanksgiving_future_days_until")
         assert state is not None
         assert int(state.state) > 0
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -20,7 +20,7 @@ async def test_single_day_trip_countdown(hass: HomeAssistant, single_day_trip_co
         await hass.async_block_till_done()
 
         # Days until start
-        sensor = hass.states.get("sensor.tagesausflug_days_until_start")
+        sensor = hass.states.get("sensor.tagesausflug_days_until")
         assert sensor is not None
         assert int(sensor.state) == 5
 
@@ -53,7 +53,7 @@ async def test_single_day_trip_on_the_day(hass: HomeAssistant, single_day_trip_c
         assert ends.state == "on"
 
         # Trip left days should be 1 (today counts)
-        left = hass.states.get("sensor.tagesausflug_trip_days_remaining")
+        left = hass.states.get("sensor.tagesausflug_trip_left_days")
         assert left is not None
         assert int(left.state) == 1
 
@@ -72,7 +72,7 @@ async def test_past_trip_negative_days(hass: HomeAssistant, past_trip_config_ent
         await hass.async_block_till_done()
 
         # Days until start should be negative
-        sensor = hass.states.get("sensor.vergangener_urlaub_days_until_start")
+        sensor = hass.states.get("sensor.vergangener_urlaub_days_until")
         assert sensor is not None
         days = int(sensor.state)
         assert days < 0  # Should be negative (trip was in 2024)
@@ -84,12 +84,12 @@ async def test_past_trip_negative_days(hass: HomeAssistant, past_trip_config_ent
         assert days_end < 0
 
         # Trip left days should be 0
-        left = hass.states.get("sensor.vergangener_urlaub_trip_days_remaining")
+        left = hass.states.get("sensor.vergangener_urlaub_trip_left_days")
         assert left is not None
         assert int(left.state) == 0
 
         # Trip left percent should be 0
-        percent = hass.states.get("sensor.vergangener_urlaub_trip_percent_remaining")
+        percent = hass.states.get("sensor.vergangener_urlaub_trip_left_percent")
         assert percent is not None
         assert float(percent.state) == 0.0
 
@@ -104,7 +104,7 @@ async def test_past_milestone_days(hass: HomeAssistant, past_milestone_config_en
         await hass.async_block_till_done()
 
         # Days until should be negative or 0
-        sensor = hass.states.get("sensor.vergangener_milestone_days_until_start")
+        sensor = hass.states.get("sensor.vergangener_milestone_days_until")
         assert sensor is not None
         days = int(sensor.state)
         assert days <= 0  # Past milestone
@@ -124,7 +124,7 @@ async def test_long_trip_countdown(hass: HomeAssistant, long_trip_config_entry):
         await hass.async_block_till_done()
 
         # Days until start
-        sensor = hass.states.get("sensor.weltreise_days_until_start")
+        sensor = hass.states.get("sensor.weltreise_days_until")
         assert sensor is not None
         assert int(sensor.state) == 31
 
@@ -150,7 +150,7 @@ async def test_long_trip_during_trip(hass: HomeAssistant, long_trip_config_entry
         assert active.state == "on"
 
         # Days until start should be negative (already started)
-        sensor = hass.states.get("sensor.weltreise_days_until_start")
+        sensor = hass.states.get("sensor.weltreise_days_until")
         assert sensor is not None
         assert int(sensor.state) < 0
 
@@ -223,7 +223,7 @@ async def test_easter_2026(hass: HomeAssistant, easter_config_entry):
         assert get_date_from_state(next_date.state) == "2026-04-05"
 
         # Days until (March 1 -> April 5 = 35 days)
-        days = hass.states.get("sensor.ostern_days_until_start")
+        days = hass.states.get("sensor.ostern_days_until")
         assert days is not None
         assert int(days.state) == 35
 
@@ -262,7 +262,7 @@ async def test_advent_2026(hass: HomeAssistant, advent_config_entry):
         assert get_date_from_state(next_date.state) == "2026-11-29"
 
         # Days until (Nov 1 -> Nov 29 = 28 days)
-        days = hass.states.get("sensor.1_advent_days_until_start")
+        days = hass.states.get("sensor.1_advent_days_until")
         assert days is not None
         assert int(days.state) == 28
 

--- a/tests/test_edge_cases_extended.py
+++ b/tests/test_edge_cases_extended.py
@@ -93,7 +93,7 @@ async def test_new_years_eve_countdown(hass: HomeAssistant, silvester_special_co
         await hass.async_block_till_done()
 
         # Should be 1 day until Dec 31
-        state = hass.states.get("sensor.silvester_test_days_until_start")
+        state = hass.states.get("sensor.silvester_test_days_until")
         assert state is not None
         assert int(state.state) == 1
 
@@ -108,7 +108,7 @@ async def test_new_year_countdown_from_previous_year(hass: HomeAssistant, neujah
         await hass.async_block_till_done()
 
         # Should be 1 day until Jan 1
-        state = hass.states.get("sensor.neujahr_test_days_until_start")
+        state = hass.states.get("sensor.neujahr_test_days_until")
         assert state is not None
         assert int(state.state) == 1
 
@@ -130,8 +130,8 @@ async def test_multiple_trips_same_time(hass: HomeAssistant, parallel_trip_1_con
     await hass.async_block_till_done()
 
     # Both should have their own sensors
-    trip1_sensor = hass.states.get("sensor.parallel_trip_1_days_until_start")
-    trip2_sensor = hass.states.get("sensor.parallel_trip_2_days_until_start")
+    trip1_sensor = hass.states.get("sensor.parallel_trip_1_days_until")
+    trip2_sensor = hass.states.get("sensor.parallel_trip_2_days_until")
 
     assert trip1_sensor is not None, "Trip 1 sensor not found"
     assert trip2_sensor is not None, "Trip 2 sensor not found"
@@ -154,8 +154,8 @@ async def test_mixed_event_types(hass: HomeAssistant, trip_config_entry, milesto
     await hass.async_block_till_done()
 
     # All three should have sensors
-    assert hass.states.get("sensor.danemark_2026_days_until_start") is not None
-    assert hass.states.get("sensor.projektabgabe_days_until_start") is not None
+    assert hass.states.get("sensor.danemark_2026_days_until") is not None
+    assert hass.states.get("sensor.projektabgabe_days_until") is not None
     assert hass.states.get("sensor.geburtstag_max_days_until_next") is not None
 
 

--- a/tests/test_entity_id_migration.py
+++ b/tests/test_entity_id_migration.py
@@ -1,0 +1,288 @@
+"""Tests for async_migrate_entry (config entry version 1 → 2).
+
+Verifies that entity IDs are renamed to English type-key suffixes on upgrade,
+that installations with already-correct IDs are left untouched, and that
+calendar entries are migrated without touching the entity registry.
+"""
+from __future__ import annotations
+
+import sys
+import os
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from custom_components.whenhub import async_migrate_entry
+from custom_components.whenhub.const import CONF_ENTRY_TYPE, ENTRY_TYPE_CALENDAR
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entry(entry_id="abc123", title="Johns Birthday", version=1, entry_type=None):
+    entry = MagicMock()
+    entry.entry_id = entry_id
+    entry.title = title
+    entry.version = version
+    data = {}
+    if entry_type is not None:
+        data[CONF_ENTRY_TYPE] = entry_type
+    entry.data = data
+    return entry
+
+
+def _make_entity(entity_id, unique_id, domain):
+    e = MagicMock()
+    e.entity_id = entity_id
+    e.unique_id = unique_id
+    e.domain = domain
+    return e
+
+
+@contextmanager
+def _patch_registry(entities, registry_lookup=None):
+    """Patch er.async_get and er.async_entries_for_config_entry."""
+    registry = MagicMock()
+    registry.async_get.side_effect = lambda eid: (registry_lookup or {}).get(eid)
+
+    with patch("custom_components.whenhub.er.async_get", return_value=registry), \
+         patch("custom_components.whenhub.er.async_entries_for_config_entry", return_value=entities):
+        yield registry
+
+
+# ---------------------------------------------------------------------------
+# Version 1 → 2: German installation
+# ---------------------------------------------------------------------------
+
+class TestMigrationV1ToV2German:
+
+    @pytest.mark.asyncio
+    async def test_event_date_renamed(self):
+        entry = _make_entry(entry_id="abc123", title="Johns Geburtstag")
+        entities = [_make_entity("sensor.johns_geburtstag_ereignisdatum", "abc123_event_date", "sensor")]
+        hass = MagicMock()
+
+        with _patch_registry(entities) as reg:
+            result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        reg.async_update_entity.assert_called_once_with(
+            "sensor.johns_geburtstag_ereignisdatum",
+            new_entity_id="sensor.johns_geburtstag_event_date",
+        )
+        hass.config_entries.async_update_entry.assert_called_once_with(entry, version=2)
+
+    @pytest.mark.asyncio
+    async def test_binary_sensor_renamed(self):
+        entry = _make_entry(entry_id="abc123", title="Johns Geburtstag")
+        entities = [_make_entity("binary_sensor.johns_geburtstag_ist_heute", "abc123_binary_is_today", "binary_sensor")]
+        hass = MagicMock()
+
+        with _patch_registry(entities) as reg:
+            result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        reg.async_update_entity.assert_called_once_with(
+            "binary_sensor.johns_geburtstag_ist_heute",
+            new_entity_id="binary_sensor.johns_geburtstag_is_today",
+        )
+
+    @pytest.mark.asyncio
+    async def test_image_entity_renamed(self):
+        entry = _make_entry(entry_id="abc123", title="Johns Geburtstag")
+        entities = [_make_entity("image.johns_geburtstag_ereignisbild", "abc123_image", "image")]
+        hass = MagicMock()
+
+        with _patch_registry(entities) as reg:
+            result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        reg.async_update_entity.assert_called_once_with(
+            "image.johns_geburtstag_ereignisbild",
+            new_entity_id="image.johns_geburtstag_event_image",
+        )
+
+    @pytest.mark.asyncio
+    async def test_multiple_entities_all_renamed(self):
+        entry = _make_entry(entry_id="abc123", title="Johns Geburtstag")
+        entities = [
+            _make_entity("sensor.johns_geburtstag_tage_bis_nachster", "abc123_days_until_next", "sensor"),
+            _make_entity("sensor.johns_geburtstag_tage_seit_letzter", "abc123_days_since_last", "sensor"),
+            _make_entity("binary_sensor.johns_geburtstag_ist_heute", "abc123_binary_is_today", "binary_sensor"),
+            _make_entity("image.johns_geburtstag_ereignisbild", "abc123_image", "image"),
+        ]
+        hass = MagicMock()
+
+        with _patch_registry(entities) as reg:
+            await async_migrate_entry(hass, entry)
+
+        assert reg.async_update_entity.call_count == 4
+
+
+# ---------------------------------------------------------------------------
+# Version 1 → 2: English installation
+# ---------------------------------------------------------------------------
+
+class TestMigrationV1ToV2English:
+
+    @pytest.mark.asyncio
+    async def test_event_date_already_correct_not_renamed(self):
+        entry = _make_entry(entry_id="abc123", title="Johns Birthday")
+        entities = [_make_entity("sensor.johns_birthday_event_date", "abc123_event_date", "sensor")]
+        hass = MagicMock()
+
+        with _patch_registry(entities) as reg:
+            await async_migrate_entry(hass, entry)
+
+        reg.async_update_entity.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_days_until_start_renamed_to_days_until(self):
+        entry = _make_entry(entry_id="abc123", title="Denmark Vacation")
+        entities = [_make_entity("sensor.denmark_vacation_days_until_start", "abc123_days_until", "sensor")]
+        hass = MagicMock()
+
+        with _patch_registry(entities) as reg:
+            await async_migrate_entry(hass, entry)
+
+        reg.async_update_entity.assert_called_once_with(
+            "sensor.denmark_vacation_days_until_start",
+            new_entity_id="sensor.denmark_vacation_days_until",
+        )
+
+    @pytest.mark.asyncio
+    async def test_trip_days_remaining_renamed(self):
+        entry = _make_entry(entry_id="abc123", title="Denmark Vacation")
+        entities = [_make_entity("sensor.denmark_vacation_trip_days_remaining", "abc123_trip_left_days", "sensor")]
+        hass = MagicMock()
+
+        with _patch_registry(entities) as reg:
+            await async_migrate_entry(hass, entry)
+
+        reg.async_update_entity.assert_called_once_with(
+            "sensor.denmark_vacation_trip_days_remaining",
+            new_entity_id="sensor.denmark_vacation_trip_left_days",
+        )
+
+    @pytest.mark.asyncio
+    async def test_trip_percent_remaining_renamed(self):
+        entry = _make_entry(entry_id="abc123", title="Denmark Vacation")
+        entities = [_make_entity("sensor.denmark_vacation_trip_percent_remaining", "abc123_trip_left_percent", "sensor")]
+        hass = MagicMock()
+
+        with _patch_registry(entities) as reg:
+            await async_migrate_entry(hass, entry)
+
+        reg.async_update_entity.assert_called_once_with(
+            "sensor.denmark_vacation_trip_percent_remaining",
+            new_entity_id="sensor.denmark_vacation_trip_left_percent",
+        )
+
+    @pytest.mark.asyncio
+    async def test_dst_active_renamed(self):
+        entry = _make_entry(entry_id="abc123", title="EU DST")
+        entities = [
+            _make_entity(
+                "binary_sensor.eu_dst_daylight_saving_time_active",
+                "abc123_binary_is_dst_active",
+                "binary_sensor",
+            )
+        ]
+        hass = MagicMock()
+
+        with _patch_registry(entities) as reg:
+            await async_migrate_entry(hass, entry)
+
+        reg.async_update_entity.assert_called_once_with(
+            "binary_sensor.eu_dst_daylight_saving_time_active",
+            new_entity_id="binary_sensor.eu_dst_is_dst_active",
+        )
+
+    @pytest.mark.asyncio
+    async def test_url_memo_already_correct(self):
+        """URL and Memo suffixes are language-neutral — no rename needed."""
+        entry = _make_entry(entry_id="abc123", title="Johns Birthday")
+        entities = [
+            _make_entity("sensor.johns_birthday_url", "abc123_url", "sensor"),
+            _make_entity("sensor.johns_birthday_memo", "abc123_memo", "sensor"),
+        ]
+        hass = MagicMock()
+
+        with _patch_registry(entities) as reg:
+            await async_migrate_entry(hass, entry)
+
+        reg.async_update_entity.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Calendar entries
+# ---------------------------------------------------------------------------
+
+class TestMigrationCalendarEntry:
+
+    @pytest.mark.asyncio
+    async def test_calendar_entry_version_bumped(self):
+        entry = _make_entry(entry_id="cal1", title="WhenHub Calendar", entry_type=ENTRY_TYPE_CALENDAR)
+        hass = MagicMock()
+
+        result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        hass.config_entries.async_update_entry.assert_called_once_with(entry, version=2)
+
+    @pytest.mark.asyncio
+    async def test_calendar_entry_no_entity_registry_access(self):
+        entry = _make_entry(entry_id="cal1", title="WhenHub Calendar", entry_type=ENTRY_TYPE_CALENDAR)
+        hass = MagicMock()
+
+        with patch("custom_components.whenhub.er.async_get") as mock_get, \
+             patch("custom_components.whenhub.er.async_entries_for_config_entry") as mock_entries:
+            await async_migrate_entry(hass, entry)
+            mock_get.assert_not_called()
+            mock_entries.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Conflict: target entity_id already occupied
+# ---------------------------------------------------------------------------
+
+class TestMigrationConflict:
+
+    @pytest.mark.asyncio
+    async def test_conflict_skips_rename(self):
+        entry = _make_entry(entry_id="abc123", title="Johns Birthday")
+        entities = [_make_entity("sensor.johns_birthday_ereignisdatum", "abc123_event_date", "sensor")]
+        existing = MagicMock()
+        hass = MagicMock()
+
+        with _patch_registry(entities, registry_lookup={"sensor.johns_birthday_event_date": existing}) as reg:
+            result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        reg.async_update_entity.assert_not_called()
+        hass.config_entries.async_update_entry.assert_called_once_with(entry, version=2)
+
+
+# ---------------------------------------------------------------------------
+# Already migrated: version >= 2
+# ---------------------------------------------------------------------------
+
+class TestMigrationAlreadyMigrated:
+
+    @pytest.mark.asyncio
+    async def test_version_2_no_op(self):
+        entry = _make_entry(version=2)
+        hass = MagicMock()
+
+        with patch("custom_components.whenhub.er.async_get") as mock_get, \
+             patch("custom_components.whenhub.er.async_entries_for_config_entry") as mock_entries:
+            result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        mock_get.assert_not_called()
+        mock_entries.assert_not_called()
+        hass.config_entries.async_update_entry.assert_not_called()

--- a/tests/test_language_entity_ids.py
+++ b/tests/test_language_entity_ids.py
@@ -1,4 +1,8 @@
-"""Test entity ID generation with different system languages."""
+"""Test that entity IDs are always language-independent (English type keys).
+
+Since v3.0.0, suggested_object_id ensures entity IDs always use the English
+sensor type key as suffix, regardless of the HA system language.
+"""
 import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -18,17 +22,15 @@ def create_trip_entry(suffix: str = ""):
             "image_path": "",
         },
         unique_id=f"whenhub_sprachtest{suffix}",
-        version=1,
+        version=2,
     )
 
 
 @pytest.mark.asyncio
-async def test_entity_id_with_english_language(hass: HomeAssistant):
-    """Test that English system creates English entity IDs."""
-    # Set system language to English
+async def test_entity_id_english_system_uses_english_keys(hass: HomeAssistant):
+    """English system: entity IDs use English type keys."""
     hass.config.language = "en"
 
-    # First load the component
     assert await async_setup_component(hass, "whenhub", {})
     await hass.async_block_till_done()
 
@@ -38,37 +40,21 @@ async def test_entity_id_with_english_language(hass: HomeAssistant):
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    # Get all sensor entity IDs
-    entity_ids = [state.entity_id for state in hass.states.async_all()]
-    sensor_ids = [eid for eid in entity_ids if eid.startswith("sensor.")]
+    sensor_ids = [s.entity_id for s in hass.states.async_all() if s.entity_id.startswith("sensor.")]
 
-    print(f"\n{'='*60}")
-    print(f"ENGLISH SYSTEM (hass.config.language = 'en')")
-    print(f"{'='*60}")
-    print(f"Sensor entity IDs:")
-    for eid in sorted(sensor_ids):
-        print(f"  - {eid}")
-
-    # Check for English patterns based on translations/en.json
-    # "days_until" -> "Days until start" -> "days_until_start"
-    has_english = any("days_until_start" in eid for eid in sensor_ids)
-    has_german = any("tage_bis_start" in eid for eid in sensor_ids)
-
-    print(f"\nPattern check:")
-    print(f"  Has English 'days_until_start': {has_english}")
-    print(f"  Has German 'tage_bis_start': {has_german}")
-
-    assert has_english, f"Expected English entity IDs, got: {sensor_ids}"
-    assert not has_german, f"Should not have German entity IDs with English language"
+    assert any("days_until" in eid for eid in sensor_ids), \
+        f"Expected 'days_until' in entity IDs, got: {sensor_ids}"
+    assert not any("days_until_start" in eid for eid in sensor_ids), \
+        f"Should not have old 'days_until_start' suffix: {sensor_ids}"
+    assert not any("tage_bis" in eid for eid in sensor_ids), \
+        f"Should not have German suffixes: {sensor_ids}"
 
 
 @pytest.mark.asyncio
-async def test_entity_id_with_german_language(hass: HomeAssistant):
-    """Test that German system creates German entity IDs."""
-    # Set system language to German
+async def test_entity_id_german_system_uses_english_keys(hass: HomeAssistant):
+    """German system: entity IDs must still use English type keys (not German)."""
     hass.config.language = "de"
 
-    # First load the component
     assert await async_setup_component(hass, "whenhub", {})
     await hass.async_block_till_done()
 
@@ -78,25 +64,11 @@ async def test_entity_id_with_german_language(hass: HomeAssistant):
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    # Get all sensor entity IDs
-    entity_ids = [state.entity_id for state in hass.states.async_all()]
-    sensor_ids = [eid for eid in entity_ids if eid.startswith("sensor.")]
+    sensor_ids = [s.entity_id for s in hass.states.async_all() if s.entity_id.startswith("sensor.")]
 
-    print(f"\n{'='*60}")
-    print(f"GERMAN SYSTEM (hass.config.language = 'de')")
-    print(f"{'='*60}")
-    print(f"Sensor entity IDs:")
-    for eid in sorted(sensor_ids):
-        print(f"  - {eid}")
-
-    # Check for German patterns based on translations/de.json
-    # "days_until" -> "Tage bis Start" -> "tage_bis_start"
-    has_english = any("days_until_start" in eid for eid in sensor_ids)
-    has_german = any("tage_bis_start" in eid for eid in sensor_ids)
-
-    print(f"\nPattern check:")
-    print(f"  Has English 'days_until_start': {has_english}")
-    print(f"  Has German 'tage_bis_start': {has_german}")
-
-    assert has_german, f"Expected German entity IDs, got: {sensor_ids}"
-    assert not has_english, f"Should not have English entity IDs with German language"
+    assert any("days_until" in eid for eid in sensor_ids), \
+        f"Expected English 'days_until' even on German HA, got: {sensor_ids}"
+    assert not any("tage_bis" in eid for eid in sensor_ids), \
+        f"German HA must not produce German entity IDs: {sensor_ids}"
+    assert not any("tage_seit" in eid for eid in sensor_ids), \
+        f"German HA must not produce German entity IDs: {sensor_ids}"

--- a/tests/test_manifest_and_setup.py
+++ b/tests/test_manifest_and_setup.py
@@ -10,11 +10,11 @@ async def test_trip_setup_creates_entities(hass: HomeAssistant, trip_config_entr
     await hass.async_block_till_done()
 
     # Check sensor entities
-    assert hass.states.get("sensor.danemark_2026_days_until_start") is not None
+    assert hass.states.get("sensor.danemark_2026_days_until") is not None
     assert hass.states.get("sensor.danemark_2026_days_until_end") is not None
     assert hass.states.get("sensor.danemark_2026_event_date") is not None
-    assert hass.states.get("sensor.danemark_2026_trip_days_remaining") is not None
-    assert hass.states.get("sensor.danemark_2026_trip_percent_remaining") is not None
+    assert hass.states.get("sensor.danemark_2026_trip_left_days") is not None
+    assert hass.states.get("sensor.danemark_2026_trip_left_percent") is not None
     
     # Check binary sensor entities
     assert hass.states.get("binary_sensor.danemark_2026_trip_starts_today") is not None
@@ -32,7 +32,7 @@ async def test_milestone_setup_creates_entities(hass: HomeAssistant, milestone_c
     await hass.async_block_till_done()
 
     # Check sensor entities
-    assert hass.states.get("sensor.projektabgabe_days_until_start") is not None
+    assert hass.states.get("sensor.projektabgabe_days_until") is not None
     assert hass.states.get("sensor.projektabgabe_event_date") is not None
     
     # Check binary sensor entity
@@ -70,7 +70,7 @@ async def test_special_setup_creates_entities(hass: HomeAssistant, special_confi
     await hass.async_block_till_done()
 
     # Check sensor entities
-    assert hass.states.get("sensor.weihnachts_countdown_days_until_start") is not None
+    assert hass.states.get("sensor.weihnachts_countdown_days_until") is not None
     assert hass.states.get("sensor.weihnachts_countdown_days_since_last") is not None
     assert hass.states.get("sensor.weihnachts_countdown_event_date") is not None
     assert hass.states.get("sensor.weihnachts_countdown_next_date") is not None

--- a/tests/test_sensor_countdown.py
+++ b/tests/test_sensor_countdown.py
@@ -15,7 +15,7 @@ async def test_trip_countdown_future_18_days(hass: HomeAssistant, trip_config_en
         await hass.async_block_till_done()
 
         # Check days until start sensor
-        sensor = hass.states.get("sensor.danemark_2026_days_until_start")
+        sensor = hass.states.get("sensor.danemark_2026_days_until")
         assert sensor is not None
         assert int(sensor.state) == 18
 
@@ -39,7 +39,7 @@ async def test_trip_active_during_trip(hass: HomeAssistant, trip_config_entry):
         assert binary.state == "on"
         
         # Check remaining days (12 days left from 15th to 26th, inclusive)
-        remaining = hass.states.get("sensor.danemark_2026_trip_days_remaining")
+        remaining = hass.states.get("sensor.danemark_2026_trip_left_days")
         assert remaining is not None
         assert int(remaining.state) == 12
 
@@ -52,7 +52,7 @@ async def test_milestone_countdown_future(hass: HomeAssistant, milestone_config_
         assert await hass.config_entries.async_setup(milestone_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        sensor = hass.states.get("sensor.projektabgabe_days_until_start")
+        sensor = hass.states.get("sensor.projektabgabe_days_until")
         assert sensor is not None
         assert int(sensor.state) == 14
 
@@ -71,7 +71,7 @@ async def test_milestone_is_today(hass: HomeAssistant, milestone_config_entry):
         assert binary.state == "on"
         
         # Days until should be 0
-        sensor = hass.states.get("sensor.projektabgabe_days_until_start")
+        sensor = hass.states.get("sensor.projektabgabe_days_until")
         assert sensor is not None
         assert int(sensor.state) == 0
 
@@ -109,7 +109,7 @@ async def test_special_christmas_countdown(hass: HomeAssistant, special_config_e
         await hass.async_block_till_done()
 
         # Check days until
-        sensor = hass.states.get("sensor.weihnachts_countdown_days_until_start")
+        sensor = hass.states.get("sensor.weihnachts_countdown_days_until")
         assert sensor is not None
         assert int(sensor.state) == 23
 

--- a/tests/test_simple_setup.py
+++ b/tests/test_simple_setup.py
@@ -42,5 +42,5 @@ async def test_manual_config_entry_setup(hass: HomeAssistant, trip_config_entry)
     assert trip_config_entry.state == ConfigEntryState.LOADED
     
     # Verify entities were created
-    assert hass.states.get("sensor.danemark_2026_days_until_start") is not None
+    assert hass.states.get("sensor.danemark_2026_days_until") is not None
     print("✅ Config entry setup through Home Assistant flow works")

--- a/tests/test_special_events.py
+++ b/tests/test_special_events.py
@@ -16,7 +16,7 @@ class TestFixedSpecialEvents:
 
         # Check that all 5 sensors are created
         base = "sensor.weihnachts_countdown"
-        assert hass.states.get(f"{base}_days_until_start") is not None
+        assert hass.states.get(f"{base}_days_until") is not None
         assert hass.states.get(f"{base}_days_since_last") is not None
         assert hass.states.get(f"{base}_event_date") is not None
         assert hass.states.get(f"{base}_next_date") is not None
@@ -29,7 +29,7 @@ class TestFixedSpecialEvents:
         assert await hass.config_entries.async_setup(special_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        state = hass.states.get("sensor.weihnachts_countdown_days_until_start")
+        state = hass.states.get("sensor.weihnachts_countdown_days_until")
         assert state is not None
         days = int(state.state)
         # Should be between 0 and 365
@@ -60,7 +60,7 @@ class TestCalculatedSpecialEvents:
 
         # Check that sensors are created
         base = "sensor.ostern"
-        assert hass.states.get(f"{base}_days_until_start") is not None
+        assert hass.states.get(f"{base}_days_until") is not None
         assert hass.states.get(f"{base}_next_date") is not None
 
     @pytest.mark.asyncio
@@ -87,7 +87,7 @@ class TestCalculatedSpecialEvents:
 
         # Check that sensors are created
         base = "sensor.1_advent"
-        assert hass.states.get(f"{base}_days_until_start") is not None
+        assert hass.states.get(f"{base}_days_until") is not None
         assert hass.states.get(f"{base}_next_date") is not None
 
     @pytest.mark.asyncio
@@ -117,11 +117,11 @@ class TestDSTEvents:
 
         # Check that sensors are created
         base = "sensor.zeitumstellung_eu"
-        assert hass.states.get(f"{base}_days_until_start") is not None
+        assert hass.states.get(f"{base}_days_until") is not None
         assert hass.states.get(f"{base}_next_date") is not None
 
         # Check binary sensor
-        assert hass.states.get("binary_sensor.zeitumstellung_eu_daylight_saving_time_active") is not None
+        assert hass.states.get("binary_sensor.zeitumstellung_eu_is_dst_active") is not None
 
     @pytest.mark.asyncio
     async def test_dst_eu_next_date_is_sunday(self, hass: HomeAssistant, dst_eu_config_entry):
@@ -146,7 +146,7 @@ class TestDSTEvents:
 
         # Check that sensors are created
         base = "sensor.dst_usa"
-        assert hass.states.get(f"{base}_days_until_start") is not None
+        assert hass.states.get(f"{base}_days_until") is not None
         assert hass.states.get(f"{base}_next_date") is not None
 
     @pytest.mark.asyncio
@@ -156,7 +156,7 @@ class TestDSTEvents:
         assert await hass.config_entries.async_setup(dst_eu_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        state = hass.states.get("binary_sensor.zeitumstellung_eu_daylight_saving_time_active")
+        state = hass.states.get("binary_sensor.zeitumstellung_eu_is_dst_active")
         assert state is not None
         # Should be either "on" or "off"
         assert state.state in ("on", "off")
@@ -169,7 +169,7 @@ class TestDSTEvents:
         await hass.async_block_till_done()
 
         base = "sensor.dst_australia"
-        assert hass.states.get(f"{base}_days_until_start") is not None
+        assert hass.states.get(f"{base}_days_until") is not None
         assert hass.states.get(f"{base}_next_date") is not None
 
     @pytest.mark.asyncio
@@ -180,7 +180,7 @@ class TestDSTEvents:
         await hass.async_block_till_done()
 
         base = "sensor.dst_new_zealand"
-        assert hass.states.get(f"{base}_days_until_start") is not None
+        assert hass.states.get(f"{base}_days_until") is not None
         assert hass.states.get(f"{base}_next_date") is not None
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds `suggested_object_id` to all entity classes (sensors, binary sensors, image, URL/memo) — ensures new entities always get English type-key suffixes regardless of HA system language
- Bumps `ConfigFlow.VERSION` to `2` to trigger automatic migration on first start after update
- Implements `async_migrate_entry` (v1→v2): renames existing entity IDs in the entity registry to the canonical English suffix; calendar entries are skipped (no sensor entities); conflict handling if target ID already occupied
- Archives old `RELEASENOTES.md` → `RELEASENOTES_v2.md`; new `RELEASENOTES.md` covers v3.0.0 with full breaking change table
- 14 new migration tests; all existing integration tests updated to new entity ID suffixes; `test_language_entity_ids.py` rewritten to verify language-independent IDs
- `TECHNICAL_REFERENCE.md` updated (naming convention section, version history)

## Breaking change

All entity ID suffixes are standardized to English type keys. Affected suffixes on all installations:

| Old | New |
|-----|-----|
| `days_until_start` | `days_until` |
| `trip_days_remaining` | `trip_left_days` |
| `trip_percent_remaining` | `trip_left_percent` |
| `daylight_saving_time_active` | `is_dst_active` |

Non-English installations additionally have all other suffixes migrated from the system language to English.

Migration runs automatically on first HA restart after update. No manual action required.

## Test plan

- [x] 562 unit/integration tests pass
- [x] 14 new migration tests (German install, English install, calendar entry, conflict, already-migrated)
- [x] Manual test on HA test system: migration triggered from version 1, entities renamed correctly in log

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)