### PR TITLE
feat: entity as date source for trip, milestone, and anniversary (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,19 @@ Trip events have a **start date** and **end date** and provide comprehensive tra
 
 When setting up a Trip event, you configure:
 
-- **Start Date**: When the trip begins (Format: YYYY-MM-DD)
-- **End Date**: When the trip ends (Format: YYYY-MM-DD)
+- **Start Date**: When the trip begins (Format: YYYY-MM-DD) — or use a date/timestamp entity as source
+- **End Date**: When the trip ends (Format: YYYY-MM-DD) — or use a date/timestamp entity as source
 - **Image** *(optional)*: Upload a file or enter a path — [see Image Management](#image-management). Default: blue airplane icon.
 - **URL** *(optional)*: A link to a booking page, website or any related URL.
 - **Memo** *(optional)*: Free-text notes — supports Markdown.
 - **Notify when expired** *(optional)*: Create a notification in [HA Repairs](#expiry-notifications) when the trip's end date has passed. Default: off.
 
+> **Entity as date source:** Enable the toggle next to a date field to pick a HA entity (`device_class: date` or `timestamp`) instead of a fixed date. The coordinator reads the entity's state on every update. When an entity source is active, the **Event Date** sensor shows the `mdi:calendar-sync` icon.
+
 ### Available Entities
 
 #### Sensors
-- **Event Date** - Start date of the trip (ISO 8601 timestamp, displays as relative time)
+- **Event Date** - Start date of the trip (ISO 8601 timestamp, displays as relative time) — icon: `mdi:calendar-sync` when any date comes from an entity
   - **Attributes**:
     - `event_name` - Name of the event
     - `event_type` - Type of event (trip)
@@ -65,6 +67,8 @@ When setting up a Trip event, you configure:
     - `breakdown_months` - Months component of countdown until start
     - `breakdown_weeks` - Weeks component of countdown until start
     - `breakdown_days` - Days component of countdown until start
+    - `start_date_source_entity` *(only when start date comes from entity)* - Entity ID of the start date source
+    - `end_date_source_entity` *(only when end date comes from entity)* - Entity ID of the end date source
 - **Days Until Start** -  Days until trip begins (can become negative if date has passed)
 - **Days Until End** - Days until trip ends (can become negative if date has passed)
 - **Trip Left Days** - Remaining days during the trip
@@ -88,16 +92,18 @@ Milestone events have a single **target date** and focus on the countdown to thi
 
 When setting up a Milestone event, you configure:
 
-- **Target Date**: The important date (Format: YYYY-MM-DD)
+- **Target Date**: The important date (Format: YYYY-MM-DD) — or use a date/timestamp entity as source
 - **Image** *(optional)*: Upload a file or enter a path — [see Image Management](#image-management). Default: red flag icon.
 - **URL** *(optional)*: A link to a website or any related URL.
 - **Memo** *(optional)*: Free-text notes — supports Markdown.
 - **Notify when expired** *(optional)*: Create a notification in [HA Repairs](#expiry-notifications) when the target date has passed. Default: off.
 
+> **Entity as date source:** Enable the toggle next to the date field to pick a HA entity (`device_class: date` or `timestamp`) instead of a fixed date. When active, the **Event Date** sensor shows the `mdi:calendar-sync` icon.
+
 ### Available Entities
 
 #### Sensors
-- **Event Date** - Target date of the milestone (ISO 8601 timestamp, displays as relative time)
+- **Event Date** - Target date of the milestone (ISO 8601 timestamp, displays as relative time) — icon: `mdi:calendar-sync` when date comes from an entity
   - **Attributes**:
     - `event_name` - Name of the event
     - `event_type` - Type of event (milestone)
@@ -105,6 +111,7 @@ When setting up a Milestone event, you configure:
     - `breakdown_months` - Months component of countdown until target
     - `breakdown_weeks` - Weeks component of countdown until target
     - `breakdown_days` - Days component of countdown until target
+    - `date_source_entity` *(only when date comes from entity)* - Entity ID of the date source
 - **Days Until** - Days until milestone (can become negative if date has passed)
 - **URL** *(optional)* — Created only when a URL is configured
 - **Memo** *(optional)* — Created only when a memo is configured
@@ -123,15 +130,17 @@ Anniversary events repeat annually based on an **original date** and provide bot
 
 When setting up an Anniversary event, you configure:
 
-- **Original Date**: The date of the first event (Format: YYYY-MM-DD)
+- **Original Date**: The date of the first event (Format: YYYY-MM-DD) — or use a date/timestamp entity as source
 - **Image** *(optional)*: Upload a file or enter a path — [see Image Management](#image-management). Default: pink heart icon.
 - **URL** *(optional)*: A link to a website or any related URL.
 - **Memo** *(optional)*: Free-text notes — supports Markdown.
 
+> **Entity as date source:** Enable the toggle next to the date field to pick a HA entity (`device_class: date` or `timestamp`) instead of a fixed date. When active, the **Event Date** sensor shows the `mdi:calendar-sync` icon.
+
 ### Available Entities
 
 #### Sensors
-- **Event Date** - Date of the next anniversary (ISO 8601 timestamp, displays as relative time)
+- **Event Date** - Date of the next anniversary (ISO 8601 timestamp, displays as relative time) — icon: `mdi:calendar-sync` when date comes from an entity
   - **Attributes**:
     - `event_name` - Name of the event
     - `event_type` - Type of event (anniversary)
@@ -141,6 +150,7 @@ When setting up an Anniversary event, you configure:
     - `breakdown_months` - Months component of countdown until next anniversary
     - `breakdown_weeks` - Weeks component of countdown until next anniversary
     - `breakdown_days` - Days component of countdown until next anniversary
+    - `date_source_entity` *(only when date comes from entity)* - Entity ID of the date source
 - **Days Until Next** - Days until next anniversary
 - **Days Since Last** - Days since last anniversary
 - **Occurrences Count** - Number of past occurrences

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ When setting up a Trip event, you configure:
 - **Memo** *(optional)*: Free-text notes — supports Markdown.
 - **Notify when expired** *(optional)*: Create a notification in [HA Repairs](#expiry-notifications) when the trip's end date has passed. Default: off.
 
-> **Entity as date source:** Enable the toggle next to a date field to pick a HA entity (`device_class: date` or `timestamp`) instead of a fixed date. The coordinator reads the entity's state on every update. When an entity source is active, the **Event Date** sensor shows the `mdi:calendar-sync` icon.
+> **Entity as date source:** Enable the toggle next to a date field to pick a HA entity (`device_class: date` or `timestamp`) instead of a fixed date. The coordinator reads the entity's state on every update. When an entity source is active, the **Event Date** sensor shows a different icon to indicate the dynamic source.
 
 ### Available Entities
 
 #### Sensors
-- **Event Date** - Start date of the trip (ISO 8601 timestamp, displays as relative time) — icon: `mdi:calendar-sync` when any date comes from an entity
+- **Event Date** - Start date of the trip (ISO 8601 timestamp, displays as relative time) — different icon when any date comes from an entity
   - **Attributes**:
     - `event_name` - Name of the event
     - `event_type` - Type of event (trip)
@@ -98,12 +98,12 @@ When setting up a Milestone event, you configure:
 - **Memo** *(optional)*: Free-text notes — supports Markdown.
 - **Notify when expired** *(optional)*: Create a notification in [HA Repairs](#expiry-notifications) when the target date has passed. Default: off.
 
-> **Entity as date source:** Enable the toggle next to the date field to pick a HA entity (`device_class: date` or `timestamp`) instead of a fixed date. When active, the **Event Date** sensor shows the `mdi:calendar-sync` icon.
+> **Entity as date source:** Enable the toggle next to the date field to pick a HA entity (`device_class: date` or `timestamp`) instead of a fixed date. When active, the **Event Date** sensor shows a different icon to indicate the dynamic source.
 
 ### Available Entities
 
 #### Sensors
-- **Event Date** - Target date of the milestone (ISO 8601 timestamp, displays as relative time) — icon: `mdi:calendar-sync` when date comes from an entity
+- **Event Date** - Target date of the milestone (ISO 8601 timestamp, displays as relative time) — different icon when date comes from an entity
   - **Attributes**:
     - `event_name` - Name of the event
     - `event_type` - Type of event (milestone)
@@ -135,12 +135,12 @@ When setting up an Anniversary event, you configure:
 - **URL** *(optional)*: A link to a website or any related URL.
 - **Memo** *(optional)*: Free-text notes — supports Markdown.
 
-> **Entity as date source:** Enable the toggle next to the date field to pick a HA entity (`device_class: date` or `timestamp`) instead of a fixed date. When active, the **Event Date** sensor shows the `mdi:calendar-sync` icon.
+> **Entity as date source:** Enable the toggle next to the date field to pick a HA entity (`device_class: date` or `timestamp`) instead of a fixed date. When active, the **Event Date** sensor shows a different icon to indicate the dynamic source.
 
 ### Available Entities
 
 #### Sensors
-- **Event Date** - Date of the next anniversary (ISO 8601 timestamp, displays as relative time) — icon: `mdi:calendar-sync` when date comes from an entity
+- **Event Date** - Date of the next anniversary (ISO 8601 timestamp, displays as relative time) — different icon when date comes from an entity
   - **Attributes**:
     - `event_name` - Name of the event
     - `event_type` - Type of event (anniversary)

--- a/TECHNICAL_REFERENCE.md
+++ b/TECHNICAL_REFERENCE.md
@@ -339,6 +339,10 @@ Each event creates multiple entities grouped under a common device.
 **Attributes on `event_date` sensor:**
 - `event_name`, `event_type`, `end_date`, `trip_duration_days`
 - `breakdown_years`, `breakdown_months`, `breakdown_weeks`, `breakdown_days`
+- `start_date_source_entity` *(only present when start date comes from a HA entity)*
+- `end_date_source_entity` *(only present when end date comes from a HA entity)*
+
+**Icon:** `mdi:calendar-sync` when start or end date is sourced from a HA entity; `mdi:calendar` otherwise.
 
 ### 3.2 Milestone Entities
 
@@ -352,6 +356,13 @@ Each event creates multiple entities grouped under a common device.
 | **Image** | `event_image` | Custom or default image |
 
 > **Conditional sensors:** See note in 3.1.
+
+**Attributes on `event_date` sensor:**
+- `event_name`, `event_type`
+- `breakdown_years`, `breakdown_months`, `breakdown_weeks`, `breakdown_days`
+- `date_source_entity` *(only present when date comes from a HA entity)*
+
+**Icon:** `mdi:calendar-sync` when date is sourced from a HA entity; `mdi:calendar` otherwise.
 
 ### 3.3 Anniversary Entities
 
@@ -368,6 +379,13 @@ Each event creates multiple entities grouped under a common device.
 | **Image** | `event_image` | Custom or default image |
 
 > **Conditional sensors:** See note in 3.1.
+
+**Attributes on `event_date` sensor:**
+- `event_name`, `event_type`, `initial_date`, `years_on_next`
+- `breakdown_years`, `breakdown_months`, `breakdown_weeks`, `breakdown_days`
+- `date_source_entity` *(only present when date comes from a HA entity)*
+
+**Icon:** `mdi:calendar-sync` when date is sourced from a HA entity; `mdi:calendar` otherwise.
 
 ### 3.4 Special Event Entities
 
@@ -653,6 +671,16 @@ The integration uses Home Assistant's `DataUpdateCoordinator` for centralized da
 Sensors will always show correct values since calculations use `date.today()` at the time of the update call. An hourly interval is sufficient for date-based countdown data.
 
 At each update cycle, the coordinator also calls `_check_expiry_repair(today)` to maintain the Repairs issue state.
+
+**Entity date source resolution:** When a date field is configured to use a HA entity, the coordinator calls `_resolve_date(entity_id, field_name)` instead of reading the static config value. This method:
+1. Reads `hass.states.get(entity_id)` — returns `None` if the entity doesn't exist
+2. Rejects states `"unavailable"` or `"unknown"` with `UpdateFailed`
+3. Delegates to `_parse_entity_date(state)` which handles:
+   - `device_class: date` → parses `YYYY-MM-DD` state string
+   - `device_class: timestamp` → parses ISO-8601 UTC timestamp, converts to local date
+4. Raises `UpdateFailed` on any parse error
+
+Trip entries may have entity sources on start date, end date, or both independently.
 
 ### 5.6 Entry Type Routing
 

--- a/custom_components/whenhub/__init__.py
+++ b/custom_components/whenhub/__init__.py
@@ -7,15 +7,27 @@ of all platforms (sensors, binary sensors, images) for event tracking.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.helpers.issue_registry import async_delete_issue
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.util import slugify
 
-from .const import DOMAIN, CONF_ENTRY_TYPE, ENTRY_TYPE_CALENDAR
+from .const import (
+    DOMAIN,
+    CONF_ENTRY_TYPE,
+    ENTRY_TYPE_CALENDAR,
+    CONF_EVENT_DATE_USE_ENTITY,
+    CONF_EVENT_DATE_ENTITY_ID,
+    CONF_START_DATE_USE_ENTITY,
+    CONF_START_DATE_ENTITY_ID,
+    CONF_END_DATE_USE_ENTITY,
+    CONF_END_DATE_ENTITY_ID,
+)
 from .coordinator import WhenHubCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -129,6 +141,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "coordinator": coordinator,
             "event_data": dict(entry.data),
         }
+        _setup_entity_date_listeners(hass, entry, coordinator)
         await hass.config_entries.async_forward_entry_setups(entry, EVENT_PLATFORMS)
 
     entry.async_on_unload(entry.add_update_listener(async_update_listener))
@@ -154,6 +167,44 @@ async def async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None
     _LOGGER.info("WhenHub integration updated: %s", entry.title)
 
 
+def _setup_entity_date_listeners(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: WhenHubCoordinator,
+) -> None:
+    """Register state-change listeners for entity date sources.
+
+    For each date field configured to use an entity as source, a listener is
+    registered so the coordinator refreshes immediately when that entity changes
+    (including transitions to/from unavailable or unknown).
+
+    Listeners are automatically removed when the entry is unloaded via
+    entry.async_on_unload().
+    """
+    data = entry.data
+    entity_ids: list[str] = []
+
+    for use_key, id_key in (
+        (CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID),
+        (CONF_START_DATE_USE_ENTITY, CONF_START_DATE_ENTITY_ID),
+        (CONF_END_DATE_USE_ENTITY, CONF_END_DATE_ENTITY_ID),
+    ):
+        if data.get(use_key) and data.get(id_key):
+            entity_ids.append(data[id_key])
+
+    if not entity_ids:
+        return
+
+    @callback
+    def _handle_entity_date_change(event: Any) -> None:  # noqa: ANN401
+        hass.async_create_task(coordinator.async_request_refresh())
+
+    for entity_id in entity_ids:
+        entry.async_on_unload(
+            async_track_state_change_event(hass, entity_id, _handle_entity_date_change)
+        )
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload WhenHub integration config entry.
 
@@ -175,8 +226,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, platforms):
-        # Clean up any open Repairs issue for this entry
+        # Clean up any open Repairs issues for this entry
         async_delete_issue(hass, DOMAIN, f"expired_{entry.entry_id}")
+        async_delete_issue(hass, DOMAIN, f"date_order_{entry.entry_id}")
 
         hass.data[DOMAIN].pop(entry.entry_id)
 

--- a/custom_components/whenhub/config_flow.py
+++ b/custom_components/whenhub/config_flow.py
@@ -17,6 +17,8 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.selector import (
     BooleanSelector,
     DateSelector,
+    EntitySelector,
+    EntitySelectorConfig,
     FileSelector,
     FileSelectorConfig,
     NumberSelector,
@@ -74,6 +76,12 @@ from .const import (
     CONF_URL,
     CONF_MEMO,
     CONF_NOTIFY_ON_EXPIRY,
+    CONF_EVENT_DATE_USE_ENTITY,
+    CONF_EVENT_DATE_ENTITY_ID,
+    CONF_START_DATE_USE_ENTITY,
+    CONF_START_DATE_ENTITY_ID,
+    CONF_END_DATE_USE_ENTITY,
+    CONF_END_DATE_ENTITY_ID,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -329,6 +337,15 @@ def _schema_cp_image(current: dict, show_delete: bool = False) -> vol.Schema:
     })
 
 
+def _schema_entity_source(entity_id_key: str, current: dict) -> vol.Schema:
+    """Schema for an entity selection step (date / timestamp device classes only)."""
+    selector = EntitySelector(EntitySelectorConfig(device_class=["date", "timestamp"]))
+    existing = current.get(entity_id_key)
+    if existing:
+        return vol.Schema({vol.Required(entity_id_key, default=existing): selector})
+    return vol.Schema({vol.Required(entity_id_key): selector})
+
+
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for WhenHub."""
 
@@ -340,6 +357,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._special_category: str | None = None
         self._calendar_data: dict = {}
         self._cp_data: dict = {}
+        self._trip_data: dict = {}       # carries data across entity selection steps
+        self._event_date_data: dict = {} # carries data across milestone/anniversary entity step
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -522,11 +541,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors = {}
 
-        start_date = user_input[CONF_START_DATE]
-        end_date = user_input[CONF_END_DATE]
+        start_use_entity = user_input.get(CONF_START_DATE_USE_ENTITY, False)
+        end_use_entity = user_input.get(CONF_END_DATE_USE_ENTITY, False)
 
-        if start_date >= end_date:
-            errors["base"] = "invalid_dates"
+        # Validate date order only when both dates are entered manually.
+        # When at least one date comes from an entity we can't check at config time.
+        if not start_use_entity and not end_use_entity:
+            if user_input[CONF_START_DATE] >= user_input[CONF_END_DATE]:
+                errors["base"] = "invalid_dates"
 
         if not errors:
             user_input[CONF_EVENT_TYPE] = self._event_type
@@ -538,9 +560,48 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     user_input["image_data"] = image_data
                     user_input[CONF_IMAGE_MIME] = image_mime
                 user_input.pop(CONF_IMAGE_UPLOAD, None)
-                return self.async_create_entry(title=self._suggest_event_name("Trip"), data=user_input)
+
+                if start_use_entity or end_use_entity:
+                    self._trip_data = user_input
+                    if start_use_entity:
+                        return await self.async_step_trip_start_entity()
+                    return await self.async_step_trip_end_entity()
+
+                return self.async_create_entry(
+                    title=self._suggest_event_name("Trip"), data=user_input
+                )
 
         return await self._show_trip_form(user_input, errors)
+
+    async def async_step_trip_start_entity(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Select the HA entity that provides the trip start date."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="trip_start_entity",
+                data_schema=_schema_entity_source(CONF_START_DATE_ENTITY_ID, self._trip_data),
+            )
+        self._trip_data[CONF_START_DATE_ENTITY_ID] = user_input[CONF_START_DATE_ENTITY_ID]
+        if self._trip_data.get(CONF_END_DATE_USE_ENTITY):
+            return await self.async_step_trip_end_entity()
+        return self.async_create_entry(
+            title=self._suggest_event_name("Trip"), data=self._trip_data
+        )
+
+    async def async_step_trip_end_entity(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Select the HA entity that provides the trip end date."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="trip_end_entity",
+                data_schema=_schema_entity_source(CONF_END_DATE_ENTITY_ID, self._trip_data),
+            )
+        self._trip_data[CONF_END_DATE_ENTITY_ID] = user_input[CONF_END_DATE_ENTITY_ID]
+        return self.async_create_entry(
+            title=self._suggest_event_name("Trip"), data=self._trip_data
+        )
 
     async def _show_trip_form(
         self, user_input: dict[str, Any] | None = None, errors: dict[str, str] | None = None
@@ -549,7 +610,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         current = user_input or {}
         data_schema = vol.Schema({
             vol.Required(CONF_START_DATE, default=current.get(CONF_START_DATE, date.today().isoformat())): DateSelector(),
+            vol.Optional(CONF_START_DATE_USE_ENTITY, default=current.get(CONF_START_DATE_USE_ENTITY, False)): BooleanSelector(),
             vol.Required(CONF_END_DATE, default=current.get(CONF_END_DATE, date.today().isoformat())): DateSelector(),
+            vol.Optional(CONF_END_DATE_USE_ENTITY, default=current.get(CONF_END_DATE_USE_ENTITY, False)): BooleanSelector(),
             **_schema_image(current),
             **_schema_url_memo(current),
             **_schema_notify_on_expiry(current),
@@ -576,7 +639,26 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_input["image_data"] = image_data
             user_input[CONF_IMAGE_MIME] = image_mime
         user_input.pop(CONF_IMAGE_UPLOAD, None)
+
+        if user_input.get(CONF_EVENT_DATE_USE_ENTITY):
+            self._event_date_data = user_input
+            return await self.async_step_milestone_entity()
+
         return self.async_create_entry(title=self._suggest_event_name("Milestone"), data=user_input)
+
+    async def async_step_milestone_entity(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Select the HA entity that provides the milestone date."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="milestone_entity",
+                data_schema=_schema_entity_source(CONF_EVENT_DATE_ENTITY_ID, self._event_date_data),
+            )
+        self._event_date_data[CONF_EVENT_DATE_ENTITY_ID] = user_input[CONF_EVENT_DATE_ENTITY_ID]
+        return self.async_create_entry(
+            title=self._suggest_event_name("Milestone"), data=self._event_date_data
+        )
 
     async def _show_milestone_form(
         self, user_input: dict[str, Any] | None = None, errors: dict[str, str] | None = None
@@ -585,6 +667,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         current = user_input or {}
         data_schema = vol.Schema({
             vol.Required(CONF_TARGET_DATE, default=current.get(CONF_TARGET_DATE, date.today().isoformat())): DateSelector(),
+            vol.Optional(CONF_EVENT_DATE_USE_ENTITY, default=current.get(CONF_EVENT_DATE_USE_ENTITY, False)): BooleanSelector(),
             **_schema_image(current),
             **_schema_url_memo(current),
             **_schema_notify_on_expiry(current),
@@ -611,7 +694,26 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             user_input["image_data"] = image_data
             user_input[CONF_IMAGE_MIME] = image_mime
         user_input.pop(CONF_IMAGE_UPLOAD, None)
+
+        if user_input.get(CONF_EVENT_DATE_USE_ENTITY):
+            self._event_date_data = user_input
+            return await self.async_step_anniversary_entity()
+
         return self.async_create_entry(title=self._suggest_event_name("Anniversary"), data=user_input)
+
+    async def async_step_anniversary_entity(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Select the HA entity that provides the anniversary start date."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="anniversary_entity",
+                data_schema=_schema_entity_source(CONF_EVENT_DATE_ENTITY_ID, self._event_date_data),
+            )
+        self._event_date_data[CONF_EVENT_DATE_ENTITY_ID] = user_input[CONF_EVENT_DATE_ENTITY_ID]
+        return self.async_create_entry(
+            title=self._suggest_event_name("Anniversary"), data=self._event_date_data
+        )
 
     async def _show_anniversary_form(
         self, user_input: dict[str, Any] | None = None, errors: dict[str, str] | None = None
@@ -620,6 +722,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         current = user_input or {}
         data_schema = vol.Schema({
             vol.Required(CONF_TARGET_DATE, default=current.get(CONF_TARGET_DATE, date.today().isoformat())): DateSelector(),
+            vol.Optional(CONF_EVENT_DATE_USE_ENTITY, default=current.get(CONF_EVENT_DATE_USE_ENTITY, False)): BooleanSelector(),
             **_schema_image(current),
             **_schema_url_memo(current),
         })
@@ -993,6 +1096,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         """Initialize the options flow."""
         self._calendar_data: dict = {}
         self._cp_data: dict = {}
+        self._trip_data: dict = {}       # carries data across entity selection steps
+        self._event_date_data: dict = {} # carries data across milestone/anniversary entity step
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -1019,6 +1124,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 return await self.async_step_cp_freq(user_input)
             return await self.async_step_special_options(user_input)
 
+    def _finalize_options(self, new_data: dict) -> FlowResult:
+        """Save updated config entry data and finish the options flow."""
+        self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
+        self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
+        return self.async_create_entry(title="", data={})
+
     async def async_step_trip_options(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -1026,11 +1137,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         errors = {}
 
         if user_input is not None:
-            start_date = user_input[CONF_START_DATE]
-            end_date = user_input[CONF_END_DATE]
+            start_use_entity = user_input.get(CONF_START_DATE_USE_ENTITY, False)
+            end_use_entity = user_input.get(CONF_END_DATE_USE_ENTITY, False)
 
-            if start_date >= end_date:
-                errors["base"] = "invalid_dates"
+            if not start_use_entity and not end_use_entity:
+                if user_input[CONF_START_DATE] >= user_input[CONF_END_DATE]:
+                    errors["base"] = "invalid_dates"
 
             if not errors:
                 user_input[CONF_EVENT_TYPE] = self.config_entry.data[CONF_EVENT_TYPE]
@@ -1041,19 +1153,20 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 if img_error:
                     errors["base"] = img_error
                 else:
-                    self.hass.config_entries.async_update_entry(
-                        self.config_entry,
-                        data=new_data,
-                    )
-
-                    self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
-                    return self.async_create_entry(title="", data={})
+                    if start_use_entity or end_use_entity:
+                        self._trip_data = new_data
+                        if start_use_entity:
+                            return await self.async_step_trip_start_entity_options()
+                        return await self.async_step_trip_end_entity_options()
+                    return self._finalize_options(new_data)
 
         current_data = user_input if user_input is not None else self.config_entry.data
         has_image = bool(self.config_entry.data.get("image_data") or self.config_entry.data.get(CONF_IMAGE_PATH))
         data_schema = vol.Schema({
             vol.Required(CONF_START_DATE, default=current_data.get(CONF_START_DATE, date.today().isoformat())): DateSelector(),
+            vol.Optional(CONF_START_DATE_USE_ENTITY, default=current_data.get(CONF_START_DATE_USE_ENTITY, False)): BooleanSelector(),
             vol.Required(CONF_END_DATE, default=current_data.get(CONF_END_DATE, date.today().isoformat())): DateSelector(),
+            vol.Optional(CONF_END_DATE_USE_ENTITY, default=current_data.get(CONF_END_DATE_USE_ENTITY, False)): BooleanSelector(),
             **_schema_image(self.config_entry.data, show_delete=has_image),
             **_schema_url_memo(self.config_entry.data),
             **_schema_notify_on_expiry(self.config_entry.data),
@@ -1064,6 +1177,32 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=data_schema,
             errors=errors,
         )
+
+    async def async_step_trip_start_entity_options(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Select/update the entity that provides the trip start date."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="trip_start_entity_options",
+                data_schema=_schema_entity_source(CONF_START_DATE_ENTITY_ID, self._trip_data),
+            )
+        self._trip_data[CONF_START_DATE_ENTITY_ID] = user_input[CONF_START_DATE_ENTITY_ID]
+        if self._trip_data.get(CONF_END_DATE_USE_ENTITY):
+            return await self.async_step_trip_end_entity_options()
+        return self._finalize_options(self._trip_data)
+
+    async def async_step_trip_end_entity_options(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Select/update the entity that provides the trip end date."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="trip_end_entity_options",
+                data_schema=_schema_entity_source(CONF_END_DATE_ENTITY_ID, self._trip_data),
+            )
+        self._trip_data[CONF_END_DATE_ENTITY_ID] = user_input[CONF_END_DATE_ENTITY_ID]
+        return self._finalize_options(self._trip_data)
 
     async def async_step_milestone_options(
         self, user_input: dict[str, Any] | None = None
@@ -1079,18 +1218,16 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             if img_error:
                 errors["base"] = img_error
             else:
-                self.hass.config_entries.async_update_entry(
-                    self.config_entry,
-                    data=new_data,
-                )
-
-                self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
-                return self.async_create_entry(title="", data={})
+                if user_input.get(CONF_EVENT_DATE_USE_ENTITY):
+                    self._event_date_data = new_data
+                    return await self.async_step_milestone_entity_options()
+                return self._finalize_options(new_data)
 
         current_data = self.config_entry.data
         has_image = bool(current_data.get("image_data") or current_data.get(CONF_IMAGE_PATH))
         data_schema = vol.Schema({
             vol.Required(CONF_TARGET_DATE, default=current_data.get(CONF_TARGET_DATE, date.today().isoformat())): DateSelector(),
+            vol.Optional(CONF_EVENT_DATE_USE_ENTITY, default=current_data.get(CONF_EVENT_DATE_USE_ENTITY, False)): BooleanSelector(),
             **_schema_image(current_data, show_delete=has_image),
             **_schema_url_memo(current_data),
             **_schema_notify_on_expiry(current_data),
@@ -1101,6 +1238,18 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=data_schema,
             errors=errors,
         )
+
+    async def async_step_milestone_entity_options(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Select/update the entity that provides the milestone date."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="milestone_entity_options",
+                data_schema=_schema_entity_source(CONF_EVENT_DATE_ENTITY_ID, self._event_date_data),
+            )
+        self._event_date_data[CONF_EVENT_DATE_ENTITY_ID] = user_input[CONF_EVENT_DATE_ENTITY_ID]
+        return self._finalize_options(self._event_date_data)
 
     async def async_step_anniversary_options(
         self, user_input: dict[str, Any] | None = None
@@ -1116,18 +1265,16 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             if img_error:
                 errors["base"] = img_error
             else:
-                self.hass.config_entries.async_update_entry(
-                    self.config_entry,
-                    data=new_data,
-                )
-
-                self.hass.data[DOMAIN][self.config_entry.entry_id] = new_data
-                return self.async_create_entry(title="", data={})
+                if user_input.get(CONF_EVENT_DATE_USE_ENTITY):
+                    self._event_date_data = new_data
+                    return await self.async_step_anniversary_entity_options()
+                return self._finalize_options(new_data)
 
         current_data = self.config_entry.data
         has_image = bool(current_data.get("image_data") or current_data.get(CONF_IMAGE_PATH))
         data_schema = vol.Schema({
             vol.Required(CONF_TARGET_DATE, default=current_data.get(CONF_TARGET_DATE, date.today().isoformat())): DateSelector(),
+            vol.Optional(CONF_EVENT_DATE_USE_ENTITY, default=current_data.get(CONF_EVENT_DATE_USE_ENTITY, False)): BooleanSelector(),
             **_schema_image(current_data, show_delete=has_image),
             **_schema_url_memo(current_data),
         })
@@ -1137,6 +1284,18 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=data_schema,
             errors=errors,
         )
+
+    async def async_step_anniversary_entity_options(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Select/update the entity that provides the anniversary start date."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="anniversary_entity_options",
+                data_schema=_schema_entity_source(CONF_EVENT_DATE_ENTITY_ID, self._event_date_data),
+            )
+        self._event_date_data[CONF_EVENT_DATE_ENTITY_ID] = user_input[CONF_EVENT_DATE_ENTITY_ID]
+        return self._finalize_options(self._event_date_data)
 
     async def async_step_special_options(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/whenhub/const.py
+++ b/custom_components/whenhub/const.py
@@ -67,6 +67,14 @@ CONF_MEMO = "memo"
 # FR13: Expiry notification via HA Repairs
 CONF_NOTIFY_ON_EXPIRY = "notify_on_expiry"
 
+# FR09: Entity date source configuration keys
+CONF_EVENT_DATE_USE_ENTITY = "event_date_use_entity"   # Milestone / Anniversary
+CONF_EVENT_DATE_ENTITY_ID = "event_date_entity_id"     # Milestone / Anniversary
+CONF_START_DATE_USE_ENTITY = "start_date_use_entity"   # Trip start
+CONF_START_DATE_ENTITY_ID = "start_date_entity_id"     # Trip start
+CONF_END_DATE_USE_ENTITY = "end_date_use_entity"       # Trip end
+CONF_END_DATE_ENTITY_ID = "end_date_entity_id"         # Trip end
+
 # Default values
 DEFAULT_IMAGE = "/local/whenhub/default_event.png"
 

--- a/custom_components/whenhub/coordinator.py
+++ b/custom_components/whenhub/coordinator.py
@@ -10,10 +10,11 @@ import logging
 from datetime import date, datetime, timedelta
 from typing import Any
 
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue, async_delete_issue
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -30,6 +31,12 @@ from .const import (
     CONF_NOTIFY_ON_EXPIRY,
     CONF_CP_END_TYPE,
     CONF_CP_UNTIL,
+    CONF_EVENT_DATE_USE_ENTITY,
+    CONF_EVENT_DATE_ENTITY_ID,
+    CONF_START_DATE_USE_ENTITY,
+    CONF_START_DATE_ENTITY_ID,
+    CONF_END_DATE_USE_ENTITY,
+    CONF_END_DATE_ENTITY_ID,
     EVENT_TYPE_TRIP,
     EVENT_TYPE_MILESTONE,
     EVENT_TYPE_ANNIVERSARY,
@@ -148,6 +155,58 @@ class WhenHubCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         return data
 
+    def _parse_entity_date(self, state: Any) -> date | None:
+        """Parse a date from an entity state object.
+
+        Supports device_class 'date' (state is YYYY-MM-DD) and
+        'timestamp' (state is ISO-8601 datetime, converted to local date).
+        """
+        device_class = state.attributes.get("device_class")
+        if device_class == "timestamp":
+            parsed = dt_util.parse_datetime(state.state)
+            if parsed:
+                return dt_util.as_local(parsed).date()
+            return None
+        # device_class == "date" or fallback
+        try:
+            return date.fromisoformat(state.state)
+        except (ValueError, TypeError):
+            return None
+
+    def _resolve_date(
+        self,
+        date_key: str,
+        use_entity_key: str,
+        entity_id_key: str,
+    ) -> date:
+        """Resolve a date from manual config or a live entity state.
+
+        Raises UpdateFailed when the entity source is configured but
+        unavailable, unknown, or returns an unparseable value.
+        Falls back to the manual date field when use_entity is False.
+        """
+        if self.event_data.get(use_entity_key):
+            entity_id = self.event_data.get(entity_id_key)
+            if not entity_id:
+                raise UpdateFailed(
+                    f"Entity date source enabled for '{date_key}' but no entity configured"
+                )
+            state = self.hass.states.get(entity_id)
+            if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+                raise UpdateFailed(
+                    f"Date source entity '{entity_id}' is unavailable or unknown"
+                )
+            resolved = self._parse_entity_date(state)
+            if resolved is None:
+                raise UpdateFailed(
+                    f"Cannot parse date from entity '{entity_id}' (state: {state.state!r})"
+                )
+            return resolved
+        raw = self.event_data.get(date_key)
+        if not raw:
+            raise UpdateFailed(f"No date configured for '{date_key}'")
+        return parse_date(raw)
+
     def _calculate_trip_data(self, today: date) -> dict[str, Any]:
         """Calculate all trip-related values.
 
@@ -157,8 +216,37 @@ class WhenHubCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         Returns:
             Dictionary with trip sensor values
         """
-        start_date = parse_date(self.event_data[CONF_START_DATE])
-        end_date = parse_date(self.event_data[CONF_END_DATE])
+        start_date = self._resolve_date(
+            CONF_START_DATE, CONF_START_DATE_USE_ENTITY, CONF_START_DATE_ENTITY_ID
+        )
+        end_date = self._resolve_date(
+            CONF_END_DATE, CONF_END_DATE_USE_ENTITY, CONF_END_DATE_ENTITY_ID
+        )
+
+        # When at least one date comes from an entity, check order at runtime.
+        # Manual-only trips are validated at config time so this can't happen there.
+        if self.event_data.get(CONF_START_DATE_USE_ENTITY) or self.event_data.get(
+            CONF_END_DATE_USE_ENTITY
+        ):
+            issue_id = f"date_order_{self.config_entry.entry_id}"
+            if end_date < start_date:
+                async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    issue_id,
+                    is_fixable=False,
+                    severity=IssueSeverity.WARNING,
+                    translation_key="date_order_invalid",
+                    translation_placeholders={
+                        "event_name": self.config_entry.title,
+                        "start_date": start_date.isoformat(),
+                        "end_date": end_date.isoformat(),
+                    },
+                )
+                raise UpdateFailed(
+                    f"Trip end date ({end_date}) is before start date ({start_date})"
+                )
+            async_delete_issue(self.hass, DOMAIN, issue_id)
 
         days_to_start = days_until(start_date, today)
         countdown = countdown_breakdown(start_date, today) if today < start_date else {}
@@ -189,7 +277,9 @@ class WhenHubCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         Returns:
             Dictionary with milestone sensor values
         """
-        target_date = parse_date(self.event_data[CONF_TARGET_DATE])
+        target_date = self._resolve_date(
+            CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+        )
 
         countdown = countdown_breakdown(target_date, today) if today < target_date else {}
 
@@ -212,7 +302,9 @@ class WhenHubCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         Returns:
             Dictionary with anniversary sensor values
         """
-        original_date = parse_date(self.event_data[CONF_TARGET_DATE])
+        original_date = self._resolve_date(
+            CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+        )
         next_ann = next_anniversary(original_date, today)
         last_ann = last_anniversary(original_date, today)
 
@@ -364,13 +456,23 @@ class WhenHubCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         expiry_date = ""
 
         if self.event_type == EVENT_TYPE_TRIP:
-            end_date = parse_date(self.event_data.get(CONF_END_DATE, ""))
+            try:
+                end_date = self._resolve_date(
+                    CONF_END_DATE, CONF_END_DATE_USE_ENTITY, CONF_END_DATE_ENTITY_ID
+                )
+            except UpdateFailed:
+                return  # Entity unavailable — skip expiry check
             if end_date is not None and end_date < today:
                 is_expired = True
                 expiry_date = end_date.isoformat()
 
         elif self.event_type == EVENT_TYPE_MILESTONE:
-            target_date = parse_date(self.event_data.get(CONF_TARGET_DATE, ""))
+            try:
+                target_date = self._resolve_date(
+                    CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+                )
+            except UpdateFailed:
+                return  # Entity unavailable — skip expiry check
             if target_date is not None and target_date < today:
                 is_expired = True
                 expiry_date = target_date.isoformat()

--- a/custom_components/whenhub/sensors/anniversary.py
+++ b/custom_components/whenhub/sensors/anniversary.py
@@ -17,6 +17,8 @@ from homeassistant.config_entries import ConfigEntry
 from ..const import (
     ANNIVERSARY_SENSOR_TYPES,
     TEXT_CALCULATION_RUNNING,
+    CONF_EVENT_DATE_USE_ENTITY,
+    CONF_EVENT_DATE_ENTITY_ID,
 )
 from .base import BaseCountdownSensor
 
@@ -83,6 +85,13 @@ class AnniversarySensor(BaseCountdownSensor):
 
         return None
 
+    @property
+    def icon(self) -> str | None:
+        """Return calendar-sync icon when date comes from an entity."""
+        if self._sensor_type == "event_date" and self._event_data.get(CONF_EVENT_DATE_USE_ENTITY):
+            return "mdi:calendar-sync"
+        return self.entity_description.icon
+
     def _get_fallback_value(self) -> datetime | int | None:
         """Get a safe fallback value based on sensor type for error scenarios.
 
@@ -117,6 +126,8 @@ class AnniversarySensor(BaseCountdownSensor):
                 "years_on_next": data.get("years_on_next", 0),
             })
             attributes.update(self._get_countdown_attributes())
+            if self._event_data.get(CONF_EVENT_DATE_USE_ENTITY):
+                attributes["date_source_entity"] = self._event_data.get(CONF_EVENT_DATE_ENTITY_ID)
             return attributes
 
         return {}

--- a/custom_components/whenhub/sensors/milestone.py
+++ b/custom_components/whenhub/sensors/milestone.py
@@ -14,6 +14,8 @@ from homeassistant.config_entries import ConfigEntry
 
 from ..const import (
     MILESTONE_SENSOR_TYPES,
+    CONF_EVENT_DATE_USE_ENTITY,
+    CONF_EVENT_DATE_ENTITY_ID,
 )
 from .base import BaseCountdownSensor
 
@@ -54,6 +56,13 @@ class MilestoneSensor(BaseCountdownSensor):
         super().__init__(coordinator, config_entry, event_data, sensor_type, MILESTONE_SENSOR_TYPES)
 
     @property
+    def icon(self) -> str | None:
+        """Return calendar-sync icon when date comes from an entity."""
+        if self._sensor_type == "event_date" and self._event_data.get(CONF_EVENT_DATE_USE_ENTITY):
+            return "mdi:calendar-sync"
+        return self.entity_description.icon
+
+    @property
     def native_value(self) -> datetime | int | float | None:
         """Return the current sensor value from coordinator data.
 
@@ -85,6 +94,8 @@ class MilestoneSensor(BaseCountdownSensor):
             data = self.coordinator.data
             attributes = self._get_base_attributes()
             attributes.update(self._get_countdown_attributes())
+            if self._event_data.get(CONF_EVENT_DATE_USE_ENTITY):
+                attributes["date_source_entity"] = self._event_data.get(CONF_EVENT_DATE_ENTITY_ID)
             return attributes
 
         return {}

--- a/custom_components/whenhub/sensors/trip.py
+++ b/custom_components/whenhub/sensors/trip.py
@@ -14,6 +14,10 @@ from homeassistant.config_entries import ConfigEntry
 
 from ..const import (
     TRIP_SENSOR_TYPES,
+    CONF_START_DATE_USE_ENTITY,
+    CONF_START_DATE_ENTITY_ID,
+    CONF_END_DATE_USE_ENTITY,
+    CONF_END_DATE_ENTITY_ID,
 )
 from .base import BaseCountdownSensor
 
@@ -52,6 +56,16 @@ class TripSensor(BaseCountdownSensor):
             sensor_type: Type of sensor to create (from TRIP_SENSOR_TYPES)
         """
         super().__init__(coordinator, config_entry, event_data, sensor_type, TRIP_SENSOR_TYPES)
+
+    @property
+    def icon(self) -> str | None:
+        """Return calendar-sync icon when any date comes from an entity."""
+        if self._sensor_type == "event_date" and (
+            self._event_data.get(CONF_START_DATE_USE_ENTITY)
+            or self._event_data.get(CONF_END_DATE_USE_ENTITY)
+        ):
+            return "mdi:calendar-sync"
+        return self.entity_description.icon
 
     @property
     def native_value(self) -> datetime | int | float | None:
@@ -96,6 +110,10 @@ class TripSensor(BaseCountdownSensor):
                 "trip_duration_days": data.get("total_days"),
             })
             attributes.update(self._get_countdown_attributes())
+            if self._event_data.get(CONF_START_DATE_USE_ENTITY):
+                attributes["start_date_source_entity"] = self._event_data.get(CONF_START_DATE_ENTITY_ID)
+            if self._event_data.get(CONF_END_DATE_USE_ENTITY):
+                attributes["end_date_source_entity"] = self._event_data.get(CONF_END_DATE_ENTITY_ID)
             return attributes
 
         return {}

--- a/custom_components/whenhub/translations/de.json
+++ b/custom_components/whenhub/translations/de.json
@@ -13,7 +13,9 @@
         "description": "Richte einen neuen Trip bei WhenHub ein",
         "data": {
           "start_date": "Startdatum",
+          "start_date_use_entity": "HA-Entity als Startdatum-Quelle verwenden",
           "end_date": "Enddatum",
+          "end_date_use_entity": "HA-Entity als Enddatum-Quelle verwenden",
           "image_upload": "Bild hochladen (optional)",
           "image_path": "Oder Bildpfad eingeben (optional)",
           "url": "URL (optional)",
@@ -22,7 +24,9 @@
         },
         "data_description": {
           "start_date": "Das Datum, an dem der Trip beginnt",
+          "start_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl einer Datums- oder Zeitstempel-Entity. Das Datumsfeld oben wird dann ignoriert.",
           "end_date": "Das Datum, an dem der Trip endet",
+          "end_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl einer Datums- oder Zeitstempel-Entity. Das Datumsfeld oben wird dann ignoriert.",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/trip.jpg — Upload hat Vorrang",
           "url": "Link zur Buchungsseite, Website oder einer anderen relevanten URL",
@@ -30,11 +34,32 @@
           "notify_on_expiry": "Erstellt eine Meldung in HA-Reparaturen, wenn dieses Event abgelaufen ist"
         }
       },
+      "trip_start_entity": {
+        "title": "Startdatum-Entity auswählen",
+        "description": "Wähle die Entity, die das Startdatum des Trips liefert. Es werden nur Datums- und Zeitstempel-Entities angezeigt.",
+        "data": {
+          "start_date_entity_id": "Startdatum-Entity"
+        },
+        "data_description": {
+          "start_date_entity_id": "Entity mit device_class 'date' (State: YYYY-MM-DD) oder 'timestamp' (ISO-8601, wird in lokales Datum umgewandelt)"
+        }
+      },
+      "trip_end_entity": {
+        "title": "Enddatum-Entity auswählen",
+        "description": "Wähle die Entity, die das Enddatum des Trips liefert. Es werden nur Datums- und Zeitstempel-Entities angezeigt.",
+        "data": {
+          "end_date_entity_id": "Enddatum-Entity"
+        },
+        "data_description": {
+          "end_date_entity_id": "Entity mit device_class 'date' (State: YYYY-MM-DD) oder 'timestamp' (ISO-8601, wird in lokales Datum umgewandelt)"
+        }
+      },
       "milestone": {
         "title": "Milestone einrichten",
         "description": "Richte einen neuen Milestone bei WhenHub ein",
         "data": {
           "target_date": "Zieldatum",
+          "event_date_use_entity": "HA-Entity als Datums-Quelle verwenden",
           "image_upload": "Bild hochladen (optional)",
           "image_path": "Oder Bildpfad eingeben (optional)",
           "url": "URL (optional)",
@@ -43,6 +68,7 @@
         },
         "data_description": {
           "target_date": "Das Datum des wichtigen Termins",
+          "event_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl einer Datums- oder Zeitstempel-Entity. Das Datumsfeld oben wird dann ignoriert.",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/milestone.jpg — Upload hat Vorrang",
           "url": "Link zu einer Website oder einer anderen relevanten URL",
@@ -50,11 +76,22 @@
           "notify_on_expiry": "Erstellt eine Meldung in HA-Reparaturen, wenn dieses Event abgelaufen ist"
         }
       },
+      "milestone_entity": {
+        "title": "Datums-Entity auswählen",
+        "description": "Wähle die Entity, die das Milestone-Datum liefert. Es werden nur Datums- und Zeitstempel-Entities angezeigt.",
+        "data": {
+          "event_date_entity_id": "Datums-Entity"
+        },
+        "data_description": {
+          "event_date_entity_id": "Entity mit device_class 'date' (State: YYYY-MM-DD) oder 'timestamp' (ISO-8601, wird in lokales Datum umgewandelt)"
+        }
+      },
       "anniversary": {
         "title": "Anniversary einrichten",
         "description": "Richte ein neues Anniversary bei WhenHub ein",
         "data": {
           "target_date": "Ursprüngliches Datum",
+          "event_date_use_entity": "HA-Entity als Datums-Quelle verwenden",
           "image_upload": "Bild hochladen (optional)",
           "image_path": "Oder Bildpfad eingeben (optional)",
           "url": "URL (optional)",
@@ -62,10 +99,21 @@
         },
         "data_description": {
           "target_date": "Das ursprüngliche Datum (wird jährlich wiederholt)",
+          "event_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl einer Datums- oder Zeitstempel-Entity. Das Datumsfeld oben wird dann ignoriert.",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/anniversary.jpg — Upload hat Vorrang",
           "url": "Link zu einer Website oder einer anderen relevanten URL",
           "memo": "Freitext-Notizen zu diesem Event — Markdown wird unterstützt"
+        }
+      },
+      "anniversary_entity": {
+        "title": "Datums-Entity auswählen",
+        "description": "Wähle die Entity, die das Anniversary-Startdatum liefert. Es werden nur Datums- und Zeitstempel-Entities angezeigt.",
+        "data": {
+          "event_date_entity_id": "Datums-Entity"
+        },
+        "data_description": {
+          "event_date_entity_id": "Entity mit device_class 'date' (State: YYYY-MM-DD) oder 'timestamp' (ISO-8601, wird in lokales Datum umgewandelt)"
         }
       },
       "special_category": {
@@ -237,6 +285,8 @@
         "title": "Trip Optionen",
         "description": "Bearbeite die Einstellungen für diesen Trip",
         "data": {
+          "start_date_use_entity": "HA-Entity als Startdatum-Quelle verwenden",
+          "end_date_use_entity": "HA-Entity als Enddatum-Quelle verwenden",
           "image_upload": "Neues Bild hochladen (optional)",
           "image_path": "Oder Bildpfad eingeben (optional)",
           "image_delete": "Aktuelles Bild entfernen",
@@ -245,6 +295,8 @@
           "notify_on_expiry": "Benachrichtigung bei Ablauf"
         },
         "data_description": {
+          "start_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl oder Änderung der Startdatum-Entity.",
+          "end_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl oder Änderung der Enddatum-Entity.",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/trip.jpg — Upload hat Vorrang",
           "url": "Link zur Buchungsseite, Website oder einer anderen relevanten URL",
@@ -252,10 +304,31 @@
           "notify_on_expiry": "Erstellt eine Meldung in HA-Reparaturen, wenn dieses Event abgelaufen ist"
         }
       },
+      "trip_start_entity_options": {
+        "title": "Startdatum-Entity auswählen",
+        "description": "Wähle oder ändere die Entity, die das Trip-Startdatum liefert.",
+        "data": {
+          "start_date_entity_id": "Startdatum-Entity"
+        },
+        "data_description": {
+          "start_date_entity_id": "Entity mit device_class 'date' oder 'timestamp'"
+        }
+      },
+      "trip_end_entity_options": {
+        "title": "Enddatum-Entity auswählen",
+        "description": "Wähle oder ändere die Entity, die das Trip-Enddatum liefert.",
+        "data": {
+          "end_date_entity_id": "Enddatum-Entity"
+        },
+        "data_description": {
+          "end_date_entity_id": "Entity mit device_class 'date' oder 'timestamp'"
+        }
+      },
       "milestone_options": {
         "title": "Milestone Optionen",
         "description": "Bearbeite die Einstellungen für diesen Milestone",
         "data": {
+          "event_date_use_entity": "HA-Entity als Datums-Quelle verwenden",
           "image_upload": "Neues Bild hochladen (optional)",
           "image_path": "Oder Bildpfad eingeben (optional)",
           "image_delete": "Aktuelles Bild entfernen",
@@ -264,6 +337,7 @@
           "notify_on_expiry": "Benachrichtigung bei Ablauf"
         },
         "data_description": {
+          "event_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl oder Änderung der Datums-Entity.",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/milestone.jpg — Upload hat Vorrang",
           "url": "Link zu einer Website oder einer anderen relevanten URL",
@@ -271,10 +345,21 @@
           "notify_on_expiry": "Erstellt eine Meldung in HA-Reparaturen, wenn dieses Event abgelaufen ist"
         }
       },
+      "milestone_entity_options": {
+        "title": "Datums-Entity auswählen",
+        "description": "Wähle oder ändere die Entity, die das Milestone-Datum liefert.",
+        "data": {
+          "event_date_entity_id": "Datums-Entity"
+        },
+        "data_description": {
+          "event_date_entity_id": "Entity mit device_class 'date' oder 'timestamp'"
+        }
+      },
       "anniversary_options": {
         "title": "Anniversary Optionen",
         "description": "Bearbeite die Einstellungen für dieses Anniversary",
         "data": {
+          "event_date_use_entity": "HA-Entity als Datums-Quelle verwenden",
           "image_upload": "Neues Bild hochladen (optional)",
           "image_path": "Oder Bildpfad eingeben (optional)",
           "image_delete": "Aktuelles Bild entfernen",
@@ -282,10 +367,21 @@
           "memo": "Memo (optional)"
         },
         "data_description": {
+          "event_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl oder Änderung der Datums-Entity.",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/anniversary.jpg — Upload hat Vorrang",
           "url": "Link zu einer Website oder einer anderen relevanten URL",
           "memo": "Freitext-Notizen zu diesem Event — Markdown wird unterstützt"
+        }
+      },
+      "anniversary_entity_options": {
+        "title": "Datums-Entity auswählen",
+        "description": "Wähle oder ändere die Entity, die das Anniversary-Startdatum liefert.",
+        "data": {
+          "event_date_entity_id": "Datums-Entity"
+        },
+        "data_description": {
+          "event_date_entity_id": "Entity mit device_class 'date' oder 'timestamp'"
         }
       },
       "special_options": {
@@ -630,6 +726,10 @@
           }
         }
       }
+    },
+    "date_order_invalid": {
+      "title": "Trip-Datumsreihenfolge ungültig: {event_name}",
+      "description": "Das entity-basierte Enddatum (**{end_date}**) liegt vor dem Startdatum (**{start_date}**) für **{event_name}**.\n\nAlle Sensoren dieses Trips sind derzeit nicht verfügbar. Passe die Quell-Entities so an, dass das Enddatum nach dem Startdatum liegt — das Problem wird dann automatisch behoben."
     }
   }
 }

--- a/custom_components/whenhub/translations/de.json
+++ b/custom_components/whenhub/translations/de.json
@@ -24,9 +24,9 @@
         },
         "data_description": {
           "start_date": "Das Datum, an dem der Trip beginnt",
-          "start_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl einer Datums- oder Zeitstempel-Entity. Das Datumsfeld oben wird dann ignoriert.",
+          "start_date_use_entity": "Datums- oder Zeitstempel-Entity statt des Datumsfeldes oben verwenden",
           "end_date": "Das Datum, an dem der Trip endet",
-          "end_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl einer Datums- oder Zeitstempel-Entity. Das Datumsfeld oben wird dann ignoriert.",
+          "end_date_use_entity": "Datums- oder Zeitstempel-Entity statt des Datumsfeldes oben verwenden",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/trip.jpg — Upload hat Vorrang",
           "url": "Link zur Buchungsseite, Website oder einer anderen relevanten URL",
@@ -36,22 +36,22 @@
       },
       "trip_start_entity": {
         "title": "Startdatum-Entity auswählen",
-        "description": "Wähle die Entity, die das Startdatum des Trips liefert. Es werden nur Datums- und Zeitstempel-Entities angezeigt.",
+        "description": "Entity auswählen, die das Startdatum liefert.",
         "data": {
           "start_date_entity_id": "Startdatum-Entity"
         },
         "data_description": {
-          "start_date_entity_id": "Entity mit device_class 'date' (State: YYYY-MM-DD) oder 'timestamp' (ISO-8601, wird in lokales Datum umgewandelt)"
+          "start_date_entity_id": "Datums- oder Zeitstempel-Entity"
         }
       },
       "trip_end_entity": {
         "title": "Enddatum-Entity auswählen",
-        "description": "Wähle die Entity, die das Enddatum des Trips liefert. Es werden nur Datums- und Zeitstempel-Entities angezeigt.",
+        "description": "Entity auswählen, die das Enddatum liefert.",
         "data": {
           "end_date_entity_id": "Enddatum-Entity"
         },
         "data_description": {
-          "end_date_entity_id": "Entity mit device_class 'date' (State: YYYY-MM-DD) oder 'timestamp' (ISO-8601, wird in lokales Datum umgewandelt)"
+          "end_date_entity_id": "Datums- oder Zeitstempel-Entity"
         }
       },
       "milestone": {
@@ -68,7 +68,7 @@
         },
         "data_description": {
           "target_date": "Das Datum des wichtigen Termins",
-          "event_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl einer Datums- oder Zeitstempel-Entity. Das Datumsfeld oben wird dann ignoriert.",
+          "event_date_use_entity": "Datums- oder Zeitstempel-Entity statt des Datumsfeldes oben verwenden",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/milestone.jpg — Upload hat Vorrang",
           "url": "Link zu einer Website oder einer anderen relevanten URL",
@@ -78,12 +78,12 @@
       },
       "milestone_entity": {
         "title": "Datums-Entity auswählen",
-        "description": "Wähle die Entity, die das Milestone-Datum liefert. Es werden nur Datums- und Zeitstempel-Entities angezeigt.",
+        "description": "Entity auswählen, die das Datum liefert.",
         "data": {
           "event_date_entity_id": "Datums-Entity"
         },
         "data_description": {
-          "event_date_entity_id": "Entity mit device_class 'date' (State: YYYY-MM-DD) oder 'timestamp' (ISO-8601, wird in lokales Datum umgewandelt)"
+          "event_date_entity_id": "Datums- oder Zeitstempel-Entity"
         }
       },
       "anniversary": {
@@ -99,7 +99,7 @@
         },
         "data_description": {
           "target_date": "Das ursprüngliche Datum (wird jährlich wiederholt)",
-          "event_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl einer Datums- oder Zeitstempel-Entity. Das Datumsfeld oben wird dann ignoriert.",
+          "event_date_use_entity": "Datums- oder Zeitstempel-Entity statt des Datumsfeldes oben verwenden",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/anniversary.jpg — Upload hat Vorrang",
           "url": "Link zu einer Website oder einer anderen relevanten URL",
@@ -108,12 +108,12 @@
       },
       "anniversary_entity": {
         "title": "Datums-Entity auswählen",
-        "description": "Wähle die Entity, die das Anniversary-Startdatum liefert. Es werden nur Datums- und Zeitstempel-Entities angezeigt.",
+        "description": "Entity auswählen, die das Datum liefert.",
         "data": {
           "event_date_entity_id": "Datums-Entity"
         },
         "data_description": {
-          "event_date_entity_id": "Entity mit device_class 'date' (State: YYYY-MM-DD) oder 'timestamp' (ISO-8601, wird in lokales Datum umgewandelt)"
+          "event_date_entity_id": "Datums- oder Zeitstempel-Entity"
         }
       },
       "special_category": {
@@ -295,8 +295,8 @@
           "notify_on_expiry": "Benachrichtigung bei Ablauf"
         },
         "data_description": {
-          "start_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl oder Änderung der Startdatum-Entity.",
-          "end_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl oder Änderung der Enddatum-Entity.",
+          "start_date_use_entity": "Datums- oder Zeitstempel-Entity statt des Datumsfeldes verwenden",
+          "end_date_use_entity": "Datums- oder Zeitstempel-Entity statt des Datumsfeldes verwenden",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/trip.jpg — Upload hat Vorrang",
           "url": "Link zur Buchungsseite, Website oder einer anderen relevanten URL",
@@ -306,7 +306,7 @@
       },
       "trip_start_entity_options": {
         "title": "Startdatum-Entity auswählen",
-        "description": "Wähle oder ändere die Entity, die das Trip-Startdatum liefert.",
+        "description": "Entity auswählen, die das Startdatum liefert.",
         "data": {
           "start_date_entity_id": "Startdatum-Entity"
         },
@@ -316,7 +316,7 @@
       },
       "trip_end_entity_options": {
         "title": "Enddatum-Entity auswählen",
-        "description": "Wähle oder ändere die Entity, die das Trip-Enddatum liefert.",
+        "description": "Entity auswählen, die das Enddatum liefert.",
         "data": {
           "end_date_entity_id": "Enddatum-Entity"
         },
@@ -337,7 +337,7 @@
           "notify_on_expiry": "Benachrichtigung bei Ablauf"
         },
         "data_description": {
-          "event_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl oder Änderung der Datums-Entity.",
+          "event_date_use_entity": "Datums- oder Zeitstempel-Entity statt des Datumsfeldes verwenden",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/milestone.jpg — Upload hat Vorrang",
           "url": "Link zu einer Website oder einer anderen relevanten URL",
@@ -347,7 +347,7 @@
       },
       "milestone_entity_options": {
         "title": "Datums-Entity auswählen",
-        "description": "Wähle oder ändere die Entity, die das Milestone-Datum liefert.",
+        "description": "Entity auswählen, die das Datum liefert.",
         "data": {
           "event_date_entity_id": "Datums-Entity"
         },
@@ -367,7 +367,7 @@
           "memo": "Memo (optional)"
         },
         "data_description": {
-          "event_date_use_entity": "Wenn aktiviert, folgt ein zusätzlicher Schritt zur Auswahl oder Änderung der Datums-Entity.",
+          "event_date_use_entity": "Datums- oder Zeitstempel-Entity statt des Datumsfeldes verwenden",
           "image_upload": "Datei hierher ziehen oder klicken — JPEG, PNG, WebP oder GIF",
           "image_path": "Pfad zu einem Bild, z.B. /local/images/anniversary.jpg — Upload hat Vorrang",
           "url": "Link zu einer Website oder einer anderen relevanten URL",
@@ -376,7 +376,7 @@
       },
       "anniversary_entity_options": {
         "title": "Datums-Entity auswählen",
-        "description": "Wähle oder ändere die Entity, die das Anniversary-Startdatum liefert.",
+        "description": "Entity auswählen, die das Datum liefert.",
         "data": {
           "event_date_entity_id": "Datums-Entity"
         },

--- a/custom_components/whenhub/translations/en.json
+++ b/custom_components/whenhub/translations/en.json
@@ -24,9 +24,9 @@
         },
         "data_description": {
           "start_date": "The date when the trip begins",
-          "start_date_use_entity": "When enabled, an extra step will appear to select a date or timestamp entity. The date field above is then ignored.",
+          "start_date_use_entity": "Use a date or timestamp entity instead of the field above",
           "end_date": "The date when the trip ends",
-          "end_date_use_entity": "When enabled, an extra step will appear to select a date or timestamp entity. The date field above is then ignored.",
+          "end_date_use_entity": "Use a date or timestamp entity instead of the field above",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/trip.jpg — upload above takes priority",
           "url": "Link to a website, booking page or any related URL",
@@ -36,22 +36,22 @@
       },
       "trip_start_entity": {
         "title": "Select start date entity",
-        "description": "Choose the entity that will provide the trip start date. Only date and timestamp entities are shown.",
+        "description": "Select the entity that provides the start date.",
         "data": {
           "start_date_entity_id": "Start date entity"
         },
         "data_description": {
-          "start_date_entity_id": "Entity with device_class 'date' (state: YYYY-MM-DD) or 'timestamp' (ISO-8601, converted to local date)"
+          "start_date_entity_id": "Date or timestamp entity"
         }
       },
       "trip_end_entity": {
         "title": "Select end date entity",
-        "description": "Choose the entity that will provide the trip end date. Only date and timestamp entities are shown.",
+        "description": "Select the entity that provides the end date.",
         "data": {
           "end_date_entity_id": "End date entity"
         },
         "data_description": {
-          "end_date_entity_id": "Entity with device_class 'date' (state: YYYY-MM-DD) or 'timestamp' (ISO-8601, converted to local date)"
+          "end_date_entity_id": "Date or timestamp entity"
         }
       },
       "milestone": {
@@ -68,7 +68,7 @@
         },
         "data_description": {
           "target_date": "The date of the important event",
-          "event_date_use_entity": "When enabled, an extra step will appear to select a date or timestamp entity. The date field above is then ignored.",
+          "event_date_use_entity": "Use a date or timestamp entity instead of the field above",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/milestone.jpg — upload above takes priority",
           "url": "Link to a website or any related URL",
@@ -78,12 +78,12 @@
       },
       "milestone_entity": {
         "title": "Select date entity",
-        "description": "Choose the entity that will provide the milestone date. Only date and timestamp entities are shown.",
+        "description": "Select the entity that provides the date.",
         "data": {
           "event_date_entity_id": "Date entity"
         },
         "data_description": {
-          "event_date_entity_id": "Entity with device_class 'date' (state: YYYY-MM-DD) or 'timestamp' (ISO-8601, converted to local date)"
+          "event_date_entity_id": "Date or timestamp entity"
         }
       },
       "anniversary": {
@@ -99,7 +99,7 @@
         },
         "data_description": {
           "target_date": "The original date (will repeat yearly)",
-          "event_date_use_entity": "When enabled, an extra step will appear to select a date or timestamp entity. The date field above is then ignored.",
+          "event_date_use_entity": "Use a date or timestamp entity instead of the field above",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/anniversary.jpg — upload above takes priority",
           "url": "Link to a website or any related URL",
@@ -108,12 +108,12 @@
       },
       "anniversary_entity": {
         "title": "Select date entity",
-        "description": "Choose the entity that will provide the anniversary start date. Only date and timestamp entities are shown.",
+        "description": "Select the entity that provides the date.",
         "data": {
           "event_date_entity_id": "Date entity"
         },
         "data_description": {
-          "event_date_entity_id": "Entity with device_class 'date' (state: YYYY-MM-DD) or 'timestamp' (ISO-8601, converted to local date)"
+          "event_date_entity_id": "Date or timestamp entity"
         }
       },
       "special_category": {
@@ -295,8 +295,8 @@
           "notify_on_expiry": "Notify when expired"
         },
         "data_description": {
-          "start_date_use_entity": "When enabled, an extra step will appear to select or change the start date entity.",
-          "end_date_use_entity": "When enabled, an extra step will appear to select or change the end date entity.",
+          "start_date_use_entity": "Use a date or timestamp entity instead of the date field",
+          "end_date_use_entity": "Use a date or timestamp entity instead of the date field",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/trip.jpg — upload above takes priority",
           "url": "Link to a website, booking page or any related URL",
@@ -306,7 +306,7 @@
       },
       "trip_start_entity_options": {
         "title": "Select start date entity",
-        "description": "Choose or change the entity that provides the trip start date.",
+        "description": "Select the entity that provides the start date.",
         "data": {
           "start_date_entity_id": "Start date entity"
         },
@@ -316,7 +316,7 @@
       },
       "trip_end_entity_options": {
         "title": "Select end date entity",
-        "description": "Choose or change the entity that provides the trip end date.",
+        "description": "Select the entity that provides the end date.",
         "data": {
           "end_date_entity_id": "End date entity"
         },
@@ -337,7 +337,7 @@
           "notify_on_expiry": "Notify when expired"
         },
         "data_description": {
-          "event_date_use_entity": "When enabled, an extra step will appear to select or change the date entity.",
+          "event_date_use_entity": "Use a date or timestamp entity instead of the date field",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/milestone.jpg — upload above takes priority",
           "url": "Link to a website or any related URL",
@@ -347,7 +347,7 @@
       },
       "milestone_entity_options": {
         "title": "Select date entity",
-        "description": "Choose or change the entity that provides the milestone date.",
+        "description": "Select the entity that provides the date.",
         "data": {
           "event_date_entity_id": "Date entity"
         },
@@ -367,7 +367,7 @@
           "memo": "Memo (optional)"
         },
         "data_description": {
-          "event_date_use_entity": "When enabled, an extra step will appear to select or change the date entity.",
+          "event_date_use_entity": "Use a date or timestamp entity instead of the date field",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/anniversary.jpg — upload above takes priority",
           "url": "Link to a website or any related URL",
@@ -376,7 +376,7 @@
       },
       "anniversary_entity_options": {
         "title": "Select date entity",
-        "description": "Choose or change the entity that provides the anniversary start date.",
+        "description": "Select the entity that provides the date.",
         "data": {
           "event_date_entity_id": "Date entity"
         },

--- a/custom_components/whenhub/translations/en.json
+++ b/custom_components/whenhub/translations/en.json
@@ -13,7 +13,9 @@
         "description": "Set up a new trip in WhenHub",
         "data": {
           "start_date": "Start date",
+          "start_date_use_entity": "Use an HA entity as start date source",
           "end_date": "End date",
+          "end_date_use_entity": "Use an HA entity as end date source",
           "image_upload": "Upload image (optional)",
           "image_path": "Or enter image path (optional)",
           "url": "URL (optional)",
@@ -22,7 +24,9 @@
         },
         "data_description": {
           "start_date": "The date when the trip begins",
+          "start_date_use_entity": "When enabled, an extra step will appear to select a date or timestamp entity. The date field above is then ignored.",
           "end_date": "The date when the trip ends",
+          "end_date_use_entity": "When enabled, an extra step will appear to select a date or timestamp entity. The date field above is then ignored.",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/trip.jpg — upload above takes priority",
           "url": "Link to a website, booking page or any related URL",
@@ -30,11 +34,32 @@
           "notify_on_expiry": "Create a notification in HA Repairs when this event expires"
         }
       },
+      "trip_start_entity": {
+        "title": "Select start date entity",
+        "description": "Choose the entity that will provide the trip start date. Only date and timestamp entities are shown.",
+        "data": {
+          "start_date_entity_id": "Start date entity"
+        },
+        "data_description": {
+          "start_date_entity_id": "Entity with device_class 'date' (state: YYYY-MM-DD) or 'timestamp' (ISO-8601, converted to local date)"
+        }
+      },
+      "trip_end_entity": {
+        "title": "Select end date entity",
+        "description": "Choose the entity that will provide the trip end date. Only date and timestamp entities are shown.",
+        "data": {
+          "end_date_entity_id": "End date entity"
+        },
+        "data_description": {
+          "end_date_entity_id": "Entity with device_class 'date' (state: YYYY-MM-DD) or 'timestamp' (ISO-8601, converted to local date)"
+        }
+      },
       "milestone": {
         "title": "Set up milestone",
         "description": "Set up a new milestone in WhenHub",
         "data": {
           "target_date": "Target date",
+          "event_date_use_entity": "Use an HA entity as date source",
           "image_upload": "Upload image (optional)",
           "image_path": "Or enter image path (optional)",
           "url": "URL (optional)",
@@ -43,6 +68,7 @@
         },
         "data_description": {
           "target_date": "The date of the important event",
+          "event_date_use_entity": "When enabled, an extra step will appear to select a date or timestamp entity. The date field above is then ignored.",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/milestone.jpg — upload above takes priority",
           "url": "Link to a website or any related URL",
@@ -50,11 +76,22 @@
           "notify_on_expiry": "Create a notification in HA Repairs when this event expires"
         }
       },
+      "milestone_entity": {
+        "title": "Select date entity",
+        "description": "Choose the entity that will provide the milestone date. Only date and timestamp entities are shown.",
+        "data": {
+          "event_date_entity_id": "Date entity"
+        },
+        "data_description": {
+          "event_date_entity_id": "Entity with device_class 'date' (state: YYYY-MM-DD) or 'timestamp' (ISO-8601, converted to local date)"
+        }
+      },
       "anniversary": {
         "title": "Set up anniversary",
         "description": "Set up a new anniversary in WhenHub",
         "data": {
           "target_date": "Original date",
+          "event_date_use_entity": "Use an HA entity as date source",
           "image_upload": "Upload image (optional)",
           "image_path": "Or enter image path (optional)",
           "url": "URL (optional)",
@@ -62,10 +99,21 @@
         },
         "data_description": {
           "target_date": "The original date (will repeat yearly)",
+          "event_date_use_entity": "When enabled, an extra step will appear to select a date or timestamp entity. The date field above is then ignored.",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/anniversary.jpg — upload above takes priority",
           "url": "Link to a website or any related URL",
           "memo": "Free-text notes about this event — supports Markdown"
+        }
+      },
+      "anniversary_entity": {
+        "title": "Select date entity",
+        "description": "Choose the entity that will provide the anniversary start date. Only date and timestamp entities are shown.",
+        "data": {
+          "event_date_entity_id": "Date entity"
+        },
+        "data_description": {
+          "event_date_entity_id": "Entity with device_class 'date' (state: YYYY-MM-DD) or 'timestamp' (ISO-8601, converted to local date)"
         }
       },
       "special_category": {
@@ -237,6 +285,8 @@
         "title": "Trip Options",
         "description": "Edit the settings for this trip",
         "data": {
+          "start_date_use_entity": "Use an HA entity as start date source",
+          "end_date_use_entity": "Use an HA entity as end date source",
           "image_upload": "Upload new image (optional)",
           "image_path": "Or enter image path (optional)",
           "image_delete": "Remove current image",
@@ -245,6 +295,8 @@
           "notify_on_expiry": "Notify when expired"
         },
         "data_description": {
+          "start_date_use_entity": "When enabled, an extra step will appear to select or change the start date entity.",
+          "end_date_use_entity": "When enabled, an extra step will appear to select or change the end date entity.",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/trip.jpg — upload above takes priority",
           "url": "Link to a website, booking page or any related URL",
@@ -252,10 +304,31 @@
           "notify_on_expiry": "Create a notification in HA Repairs when this event expires"
         }
       },
+      "trip_start_entity_options": {
+        "title": "Select start date entity",
+        "description": "Choose or change the entity that provides the trip start date.",
+        "data": {
+          "start_date_entity_id": "Start date entity"
+        },
+        "data_description": {
+          "start_date_entity_id": "Entity with device_class 'date' or 'timestamp'"
+        }
+      },
+      "trip_end_entity_options": {
+        "title": "Select end date entity",
+        "description": "Choose or change the entity that provides the trip end date.",
+        "data": {
+          "end_date_entity_id": "End date entity"
+        },
+        "data_description": {
+          "end_date_entity_id": "Entity with device_class 'date' or 'timestamp'"
+        }
+      },
       "milestone_options": {
         "title": "Milestone Options",
         "description": "Edit the settings for this milestone",
         "data": {
+          "event_date_use_entity": "Use an HA entity as date source",
           "image_upload": "Upload new image (optional)",
           "image_path": "Or enter image path (optional)",
           "image_delete": "Remove current image",
@@ -264,6 +337,7 @@
           "notify_on_expiry": "Notify when expired"
         },
         "data_description": {
+          "event_date_use_entity": "When enabled, an extra step will appear to select or change the date entity.",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/milestone.jpg — upload above takes priority",
           "url": "Link to a website or any related URL",
@@ -271,10 +345,21 @@
           "notify_on_expiry": "Create a notification in HA Repairs when this event expires"
         }
       },
+      "milestone_entity_options": {
+        "title": "Select date entity",
+        "description": "Choose or change the entity that provides the milestone date.",
+        "data": {
+          "event_date_entity_id": "Date entity"
+        },
+        "data_description": {
+          "event_date_entity_id": "Entity with device_class 'date' or 'timestamp'"
+        }
+      },
       "anniversary_options": {
         "title": "Anniversary Options",
         "description": "Edit the settings for this anniversary",
         "data": {
+          "event_date_use_entity": "Use an HA entity as date source",
           "image_upload": "Upload new image (optional)",
           "image_path": "Or enter image path (optional)",
           "image_delete": "Remove current image",
@@ -282,10 +367,21 @@
           "memo": "Memo (optional)"
         },
         "data_description": {
+          "event_date_use_entity": "When enabled, an extra step will appear to select or change the date entity.",
           "image_upload": "Drag & drop or click to select a JPEG, PNG, WebP or GIF file",
           "image_path": "Path to an image, e.g. /local/images/anniversary.jpg — upload above takes priority",
           "url": "Link to a website or any related URL",
           "memo": "Free-text notes about this event — supports Markdown"
+        }
+      },
+      "anniversary_entity_options": {
+        "title": "Select date entity",
+        "description": "Choose or change the entity that provides the anniversary start date.",
+        "data": {
+          "event_date_entity_id": "Date entity"
+        },
+        "data_description": {
+          "event_date_entity_id": "Entity with device_class 'date' or 'timestamp'"
         }
       },
       "special_options": {
@@ -630,6 +726,10 @@
           }
         }
       }
+    },
+    "date_order_invalid": {
+      "title": "Trip date order invalid: {event_name}",
+      "description": "The entity-sourced end date (**{end_date}**) is before the start date (**{start_date}**) for **{event_name}**.\n\nAll sensors for this trip are currently unavailable. Update the source entities so that the end date is after the start date to resolve this issue automatically."
     }
   }
 }

--- a/tests/test_entity_date_source.py
+++ b/tests/test_entity_date_source.py
@@ -1,0 +1,774 @@
+"""Tests for FR9: Entity as date source.
+
+Tests:
+- WhenHubCoordinator._parse_entity_date() — unit tests with stubs
+- WhenHubCoordinator._resolve_date() — unit tests with stubs
+- Config flow routing when entity checkboxes are checked
+- Options flow routing when switching to entity source
+"""
+from __future__ import annotations
+
+import sys
+import os
+from datetime import date
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from custom_components.whenhub.const import (
+    DOMAIN,
+    CONF_TARGET_DATE,
+    CONF_START_DATE,
+    CONF_END_DATE,
+    CONF_EVENT_DATE_USE_ENTITY,
+    CONF_EVENT_DATE_ENTITY_ID,
+    CONF_START_DATE_USE_ENTITY,
+    CONF_START_DATE_ENTITY_ID,
+    CONF_END_DATE_USE_ENTITY,
+    CONF_END_DATE_ENTITY_ID,
+    EVENT_TYPE_TRIP,
+    EVENT_TYPE_MILESTONE,
+    EVENT_TYPE_ANNIVERSARY,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stubs for unit tests (no full HA runtime needed)
+# ---------------------------------------------------------------------------
+
+class _FakeHass:
+    """Minimal hass stub with a controllable state store."""
+
+    def __init__(self):
+        self._states: dict = {}
+
+    def set_state(self, entity_id: str, state_value: str, attributes: dict | None = None) -> None:
+        mock_state = MagicMock()
+        mock_state.state = state_value
+        mock_state.attributes = attributes or {}
+        self._states[entity_id] = mock_state
+
+    @property
+    def states(self):
+        store = self._states
+        mock = MagicMock()
+        mock.get = lambda eid: store.get(eid)
+        return mock
+
+
+class _FakeConfigEntry:
+    def __init__(self, entry_id: str = "test_id", title: str = "Test Event"):
+        self.entry_id = entry_id
+        self.title = title
+
+
+def _make_coordinator(event_type: str, event_data: dict, hass: _FakeHass | None = None):
+    """Create a WhenHubCoordinator bypassing __init__."""
+    from custom_components.whenhub.coordinator import WhenHubCoordinator
+
+    coord = object.__new__(WhenHubCoordinator)
+    coord.hass = hass or _FakeHass()
+    coord.config_entry = _FakeConfigEntry()
+    coord.event_type = event_type
+    coord.event_data = event_data
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# Tests for _parse_entity_date
+# ---------------------------------------------------------------------------
+
+class TestParseEntityDate:
+    """Unit tests for WhenHubCoordinator._parse_entity_date()."""
+
+    def _make_state(self, state_value: str, device_class: str | None = None) -> MagicMock:
+        mock = MagicMock()
+        mock.state = state_value
+        mock.attributes = {"device_class": device_class} if device_class else {}
+        return mock
+
+    def test_date_device_class_returns_correct_date(self):
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, {})
+        state = self._make_state("2026-06-15", device_class="date")
+        assert coord._parse_entity_date(state) == date(2026, 6, 15)
+
+    def test_date_device_class_invalid_string_returns_none(self):
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, {})
+        state = self._make_state("not-a-date", device_class="date")
+        assert coord._parse_entity_date(state) is None
+
+    def test_timestamp_device_class_returns_a_date(self):
+        """Timestamp entities return a date (exact value is timezone-dependent)."""
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, {})
+        state = self._make_state("2026-07-20T10:00:00+00:00", device_class="timestamp")
+        result = coord._parse_entity_date(state)
+        assert isinstance(result, date)
+
+    def test_timestamp_device_class_unparseable_returns_none(self):
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, {})
+        state = self._make_state("not-a-timestamp", device_class="timestamp")
+        assert coord._parse_entity_date(state) is None
+
+    def test_no_device_class_falls_back_to_date_parse(self):
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, {})
+        state = self._make_state("2026-12-25")  # no device_class attribute
+        assert coord._parse_entity_date(state) == date(2026, 12, 25)
+
+    def test_no_device_class_invalid_string_returns_none(self):
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, {})
+        state = self._make_state("invalid")
+        assert coord._parse_entity_date(state) is None
+
+    def test_different_dates_return_correctly(self):
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, {})
+        for date_str, expected in [
+            ("2024-02-29", date(2024, 2, 29)),   # leap year
+            ("2000-01-01", date(2000, 1, 1)),
+            ("2099-12-31", date(2099, 12, 31)),
+        ]:
+            state = self._make_state(date_str, device_class="date")
+            assert coord._parse_entity_date(state) == expected
+
+
+# ---------------------------------------------------------------------------
+# Tests for _resolve_date
+# ---------------------------------------------------------------------------
+
+class TestResolveDate:
+    """Unit tests for WhenHubCoordinator._resolve_date()."""
+
+    def test_manual_mode_returns_configured_date(self):
+        data = {CONF_TARGET_DATE: "2026-09-01"}
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, data)
+        result = coord._resolve_date(
+            CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+        )
+        assert result == date(2026, 9, 1)
+
+    def test_manual_mode_empty_date_raises_update_failed(self):
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, {CONF_TARGET_DATE: ""})
+        with pytest.raises(UpdateFailed):
+            coord._resolve_date(
+                CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+            )
+
+    def test_manual_mode_missing_key_raises_update_failed(self):
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, {})
+        with pytest.raises(UpdateFailed):
+            coord._resolve_date(
+                CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+            )
+
+    def test_entity_mode_date_entity_returns_correct_date(self):
+        hass = _FakeHass()
+        hass.set_state("sensor.my_date", "2026-10-01", {"device_class": "date"})
+        data = {
+            CONF_EVENT_DATE_USE_ENTITY: True,
+            CONF_EVENT_DATE_ENTITY_ID: "sensor.my_date",
+        }
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, data, hass)
+        result = coord._resolve_date(
+            CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+        )
+        assert result == date(2026, 10, 1)
+
+    def test_entity_mode_timestamp_entity_returns_a_date(self):
+        hass = _FakeHass()
+        hass.set_state("sensor.ts", "2026-10-15T00:00:00+00:00", {"device_class": "timestamp"})
+        data = {
+            CONF_EVENT_DATE_USE_ENTITY: True,
+            CONF_EVENT_DATE_ENTITY_ID: "sensor.ts",
+        }
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, data, hass)
+        result = coord._resolve_date(
+            CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+        )
+        assert isinstance(result, date)
+
+    def test_entity_mode_no_entity_id_configured_raises_update_failed(self):
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+        data = {CONF_EVENT_DATE_USE_ENTITY: True}  # no entity_id key
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, data)
+        with pytest.raises(UpdateFailed):
+            coord._resolve_date(
+                CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+            )
+
+    def test_entity_mode_entity_not_in_hass_raises_update_failed(self):
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+        data = {
+            CONF_EVENT_DATE_USE_ENTITY: True,
+            CONF_EVENT_DATE_ENTITY_ID: "sensor.does_not_exist",
+        }
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, data)  # empty hass
+        with pytest.raises(UpdateFailed):
+            coord._resolve_date(
+                CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+            )
+
+    def test_entity_mode_unavailable_state_raises_update_failed(self):
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+        hass = _FakeHass()
+        hass.set_state("sensor.date", "unavailable", {"device_class": "date"})
+        data = {
+            CONF_EVENT_DATE_USE_ENTITY: True,
+            CONF_EVENT_DATE_ENTITY_ID: "sensor.date",
+        }
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, data, hass)
+        with pytest.raises(UpdateFailed):
+            coord._resolve_date(
+                CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+            )
+
+    def test_entity_mode_unknown_state_raises_update_failed(self):
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+        hass = _FakeHass()
+        hass.set_state("sensor.date", "unknown", {"device_class": "date"})
+        data = {
+            CONF_EVENT_DATE_USE_ENTITY: True,
+            CONF_EVENT_DATE_ENTITY_ID: "sensor.date",
+        }
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, data, hass)
+        with pytest.raises(UpdateFailed):
+            coord._resolve_date(
+                CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+            )
+
+    def test_entity_mode_unparseable_state_raises_update_failed(self):
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+        hass = _FakeHass()
+        hass.set_state("sensor.date", "not-a-date", {"device_class": "date"})
+        data = {
+            CONF_EVENT_DATE_USE_ENTITY: True,
+            CONF_EVENT_DATE_ENTITY_ID: "sensor.date",
+        }
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, data, hass)
+        with pytest.raises(UpdateFailed):
+            coord._resolve_date(
+                CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+            )
+
+    def test_trip_start_date_via_entity(self):
+        hass = _FakeHass()
+        hass.set_state("sensor.start", "2026-08-01", {"device_class": "date"})
+        data = {
+            CONF_START_DATE_USE_ENTITY: True,
+            CONF_START_DATE_ENTITY_ID: "sensor.start",
+        }
+        coord = _make_coordinator(EVENT_TYPE_TRIP, data, hass)
+        result = coord._resolve_date(
+            CONF_START_DATE, CONF_START_DATE_USE_ENTITY, CONF_START_DATE_ENTITY_ID
+        )
+        assert result == date(2026, 8, 1)
+
+    def test_trip_end_date_via_entity(self):
+        hass = _FakeHass()
+        hass.set_state("sensor.end", "2026-08-15", {"device_class": "date"})
+        data = {
+            CONF_END_DATE_USE_ENTITY: True,
+            CONF_END_DATE_ENTITY_ID: "sensor.end",
+        }
+        coord = _make_coordinator(EVENT_TYPE_TRIP, data, hass)
+        result = coord._resolve_date(
+            CONF_END_DATE, CONF_END_DATE_USE_ENTITY, CONF_END_DATE_ENTITY_ID
+        )
+        assert result == date(2026, 8, 15)
+
+    def test_manual_mode_explicit_false_uses_manual_date(self):
+        """Explicit use_entity=False must fall through to manual date, not entity."""
+        hass = _FakeHass()
+        hass.set_state("sensor.ignored", "2099-01-01", {"device_class": "date"})
+        data = {
+            CONF_EVENT_DATE_USE_ENTITY: False,
+            CONF_EVENT_DATE_ENTITY_ID: "sensor.ignored",
+            CONF_TARGET_DATE: "2026-03-15",
+        }
+        coord = _make_coordinator(EVENT_TYPE_MILESTONE, data, hass)
+        result = coord._resolve_date(
+            CONF_TARGET_DATE, CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID
+        )
+        assert result == date(2026, 3, 15)
+
+
+# ---------------------------------------------------------------------------
+# Config flow routing tests (require full HA runtime)
+# ---------------------------------------------------------------------------
+
+class TestConfigFlowEntityRouting:
+    """Test that entity checkboxes correctly route the config flow."""
+
+    @pytest.mark.asyncio
+    async def test_trip_no_entity_creates_entry_directly(self, hass):
+        """Trip without entity checkboxes creates entry without extra steps."""
+        from homeassistant.data_entry_flow import FlowResultType
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"event_type": "trip"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "start_date": "2026-08-01",
+                "end_date": "2026-08-15",
+                "start_date_use_entity": False,
+                "end_date_use_entity": False,
+                "image_path": "",
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"]["start_date"] == "2026-08-01"
+        assert result["data"].get("start_date_use_entity") is False
+
+    @pytest.mark.asyncio
+    async def test_trip_start_entity_routes_to_start_entity_step(self, hass):
+        """start_date_use_entity=True routes to trip_start_entity step."""
+        from homeassistant.data_entry_flow import FlowResultType
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"event_type": "trip"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "start_date": "2026-08-01",
+                "end_date": "2026-08-15",
+                "start_date_use_entity": True,
+                "end_date_use_entity": False,
+                "image_path": "",
+            },
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "trip_start_entity"
+
+    @pytest.mark.asyncio
+    async def test_trip_end_entity_only_routes_to_end_entity_step(self, hass):
+        """end_date_use_entity=True (without start) routes to trip_end_entity step."""
+        from homeassistant.data_entry_flow import FlowResultType
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"event_type": "trip"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "start_date": "2026-08-01",
+                "end_date": "2026-08-15",
+                "start_date_use_entity": False,
+                "end_date_use_entity": True,
+                "image_path": "",
+            },
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "trip_end_entity"
+
+    @pytest.mark.asyncio
+    async def test_trip_both_entities_start_entity_step_shown_first(self, hass):
+        """Both entity checkboxes → trip_start_entity step shown first."""
+        from homeassistant.data_entry_flow import FlowResultType
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"event_type": "trip"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "start_date": "2026-08-01",
+                "end_date": "2026-08-15",
+                "start_date_use_entity": True,
+                "end_date_use_entity": True,
+                "image_path": "",
+            },
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "trip_start_entity"
+
+    @pytest.mark.asyncio
+    async def test_trip_both_entities_full_flow_creates_entry(self, hass):
+        """Both entity checkboxes → start entity → end entity → entry created."""
+        from homeassistant.data_entry_flow import FlowResultType
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"event_type": "trip"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "start_date": "2026-08-01",
+                "end_date": "2026-08-15",
+                "start_date_use_entity": True,
+                "end_date_use_entity": True,
+                "image_path": "",
+            },
+        )
+        assert result["step_id"] == "trip_start_entity"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"start_date_entity_id": "sensor.trip_start"}
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "trip_end_entity"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"end_date_entity_id": "sensor.trip_end"}
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"]["start_date_use_entity"] is True
+        assert result["data"]["end_date_use_entity"] is True
+        assert result["data"]["start_date_entity_id"] == "sensor.trip_start"
+        assert result["data"]["end_date_entity_id"] == "sensor.trip_end"
+
+    @pytest.mark.asyncio
+    async def test_trip_start_entity_only_full_flow(self, hass):
+        """Start entity only → start entity step → entry (no end entity step)."""
+        from homeassistant.data_entry_flow import FlowResultType
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"event_type": "trip"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "start_date": "2026-08-01",
+                "end_date": "2026-08-15",
+                "start_date_use_entity": True,
+                "end_date_use_entity": False,
+                "image_path": "",
+            },
+        )
+        assert result["step_id"] == "trip_start_entity"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"start_date_entity_id": "sensor.trip_start"}
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"]["start_date_use_entity"] is True
+        assert result["data"]["start_date_entity_id"] == "sensor.trip_start"
+        assert result["data"].get("end_date_use_entity") is False
+
+    @pytest.mark.asyncio
+    async def test_milestone_entity_checkbox_routes_to_entity_step(self, hass):
+        """Milestone event_date_use_entity routes to milestone_entity step."""
+        from homeassistant.data_entry_flow import FlowResultType
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"event_type": "milestone"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "target_date": "2026-12-31",
+                "event_date_use_entity": True,
+                "image_path": "",
+            },
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "milestone_entity"
+
+    @pytest.mark.asyncio
+    async def test_milestone_entity_full_flow_creates_entry(self, hass):
+        """Milestone entity checkbox → entity step → entry created."""
+        from homeassistant.data_entry_flow import FlowResultType
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"event_type": "milestone"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "target_date": "2026-12-31",
+                "event_date_use_entity": True,
+                "image_path": "",
+            },
+        )
+        assert result["step_id"] == "milestone_entity"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"event_date_entity_id": "input_datetime.my_milestone"}
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"]["event_date_use_entity"] is True
+        assert result["data"]["event_date_entity_id"] == "input_datetime.my_milestone"
+
+    @pytest.mark.asyncio
+    async def test_milestone_no_entity_creates_entry_directly(self, hass):
+        """Milestone without entity checkbox creates entry without extra step."""
+        from homeassistant.data_entry_flow import FlowResultType
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"event_type": "milestone"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "target_date": "2026-12-31",
+                "event_date_use_entity": False,
+                "image_path": "",
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"]["target_date"] == "2026-12-31"
+
+    @pytest.mark.asyncio
+    async def test_anniversary_entity_checkbox_routes_to_entity_step(self, hass):
+        """Anniversary event_date_use_entity routes to anniversary_entity step."""
+        from homeassistant.data_entry_flow import FlowResultType
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"event_type": "anniversary"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "target_date": "2010-05-20",
+                "event_date_use_entity": True,
+                "image_path": "",
+            },
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "anniversary_entity"
+
+    @pytest.mark.asyncio
+    async def test_anniversary_entity_full_flow_creates_entry(self, hass):
+        """Anniversary entity checkbox → entity step → entry created."""
+        from homeassistant.data_entry_flow import FlowResultType
+
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {"event_type": "anniversary"})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "target_date": "2010-05-20",
+                "event_date_use_entity": True,
+                "image_path": "",
+            },
+        )
+        assert result["step_id"] == "anniversary_entity"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"event_date_entity_id": "sensor.birthday_date"}
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["data"]["event_date_use_entity"] is True
+        assert result["data"]["event_date_entity_id"] == "sensor.birthday_date"
+
+
+# ---------------------------------------------------------------------------
+# Options flow routing tests (require full HA runtime)
+# ---------------------------------------------------------------------------
+
+class TestOptionsFlowEntityRouting:
+    """Test options flow routing when enabling entity source."""
+
+    @pytest.mark.asyncio
+    async def test_trip_options_no_entity_finishes_directly(self, hass):
+        """Trip options without entity checkboxes finishes without extra steps."""
+        from pytest_homeassistant_custom_component.common import MockConfigEntry
+        from homeassistant.data_entry_flow import FlowResultType
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                "event_type": "trip",
+                "start_date": "2026-07-01",
+                "end_date": "2026-07-15",
+                "image_path": "",
+            },
+            title="Test Trip",
+            version=2,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                "start_date": "2026-08-01",
+                "end_date": "2026-08-15",
+                "start_date_use_entity": False,
+                "end_date_use_entity": False,
+                "image_path": "",
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    @pytest.mark.asyncio
+    async def test_trip_options_start_entity_routes_to_entity_step(self, hass):
+        """Trip options: enabling start entity routes to trip_start_entity_options."""
+        from pytest_homeassistant_custom_component.common import MockConfigEntry
+        from homeassistant.data_entry_flow import FlowResultType
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                "event_type": "trip",
+                "start_date": "2026-07-01",
+                "end_date": "2026-07-15",
+                "image_path": "",
+            },
+            title="Test Trip",
+            version=2,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["step_id"] == "trip_options"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                "start_date": "2026-07-01",
+                "end_date": "2026-07-15",
+                "start_date_use_entity": True,
+                "end_date_use_entity": False,
+                "image_path": "",
+            },
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "trip_start_entity_options"
+
+    @pytest.mark.asyncio
+    async def test_trip_options_both_entities_full_flow(self, hass):
+        """Trip options: both entity checkboxes → start entity → end entity → done."""
+        from pytest_homeassistant_custom_component.common import MockConfigEntry
+        from homeassistant.data_entry_flow import FlowResultType
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                "event_type": "trip",
+                "start_date": "2026-07-01",
+                "end_date": "2026-07-15",
+                "image_path": "",
+            },
+            title="Test Trip",
+            version=2,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                "start_date": "2026-07-01",
+                "end_date": "2026-07-15",
+                "start_date_use_entity": True,
+                "end_date_use_entity": True,
+                "image_path": "",
+            },
+        )
+        assert result["step_id"] == "trip_start_entity_options"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"start_date_entity_id": "sensor.trip_start"}
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "trip_end_entity_options"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"end_date_entity_id": "sensor.trip_end"}
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    @pytest.mark.asyncio
+    async def test_milestone_options_entity_routes_to_entity_step(self, hass):
+        """Milestone options: enabling entity checkbox routes to milestone_entity_options."""
+        from pytest_homeassistant_custom_component.common import MockConfigEntry
+        from homeassistant.data_entry_flow import FlowResultType
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                "event_type": "milestone",
+                "target_date": "2026-12-31",
+                "image_path": "",
+            },
+            title="Test Milestone",
+            version=2,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["step_id"] == "milestone_options"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                "target_date": "2026-12-31",
+                "event_date_use_entity": True,
+                "image_path": "",
+            },
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "milestone_entity_options"
+
+    @pytest.mark.asyncio
+    async def test_milestone_options_entity_full_flow(self, hass):
+        """Milestone options: entity step → finalize."""
+        from pytest_homeassistant_custom_component.common import MockConfigEntry
+        from homeassistant.data_entry_flow import FlowResultType
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                "event_type": "milestone",
+                "target_date": "2026-12-31",
+                "image_path": "",
+            },
+            title="Test Milestone",
+            version=2,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                "target_date": "2026-12-31",
+                "event_date_use_entity": True,
+                "image_path": "",
+            },
+        )
+        assert result["step_id"] == "milestone_entity_options"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"event_date_entity_id": "input_datetime.my_date"}
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    @pytest.mark.asyncio
+    async def test_anniversary_options_entity_routes_to_entity_step(self, hass):
+        """Anniversary options: enabling entity checkbox routes to anniversary_entity_options."""
+        from pytest_homeassistant_custom_component.common import MockConfigEntry
+        from homeassistant.data_entry_flow import FlowResultType
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                "event_type": "anniversary",
+                "target_date": "2010-05-20",
+                "image_path": "",
+            },
+            title="Test Anniversary",
+            version=2,
+        )
+        entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["step_id"] == "anniversary_options"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                "target_date": "2010-05-20",
+                "event_date_use_entity": True,
+                "image_path": "",
+            },
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "anniversary_entity_options"


### PR DESCRIPTION
## Summary

Adds the ability to use a Home Assistant entity (`device_class: date` or `timestamp`) as the date source for trip, milestone, and anniversary events instead of a fixed date.

- Trip: start date and/or end date can come from an entity (independently)
- Milestone: target date can come from an entity
- Anniversary: original date can come from an entity

## Changes

- **`const.py`**: New config keys (`CONF_EVENT_DATE_USE_ENTITY`, `CONF_EVENT_DATE_ENTITY_ID`, `CONF_START_DATE_USE_ENTITY`, etc.)
- **`coordinator.py`**: `_parse_entity_date()` and `_resolve_date()` for reading and validating entity states; integrated into all three event type calculations
- **`config_flow.py`**: Entity source toggle + entity selector step for all affected event types (Config Flow + Options Flow)
- **`sensors/trip.py`**, **`sensors/milestone.py`**, **`sensors/anniversary.py`**: Dynamic icon (`mdi:calendar-sync` when entity source active) + `date_source_entity` / `start_date_source_entity` / `end_date_source_entity` state attributes
- **`translations/en.json`**, **`translations/de.json`**: All new config/options steps translated
- **`README.md`**, **`TECHNICAL_REFERENCE.md`**: Feature documented
- **`tests/test_entity_date_source.py`**: 37 new tests (unit + integration)

## Test plan

- [x] 599 tests passing
- [x] Synced to HA test system
- [ ] Manual test: configure trip with entity start date, rename entity → see #19
- [ ] Manual test: entity unavailable → coordinator retries next cycle

## Related

- Closes #9
- Follow-up: #19 (entity registry tracking — auto-migrate on rename, Repairs issue on delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)