### PR TITLE
feat: entity registry tracking for entity date sources (closes #19)

### DIFF
--- a/custom_components/whenhub/__init__.py
+++ b/custom_components/whenhub/__init__.py
@@ -36,6 +36,9 @@ _LOGGER = logging.getLogger(__name__)
 EVENT_PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.IMAGE, Platform.BINARY_SENSOR]
 CALENDAR_PLATFORMS: list[Platform] = [Platform.CALENDAR]
 
+# Key in hass.data[DOMAIN] for tracking entity restore listeners (per entry_id)
+_RESTORE_LISTENER_KEY = "_entity_restore_listeners"
+
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate config entry to the current version.
@@ -248,13 +251,21 @@ def _setup_entity_registry_listener(hass: HomeAssistant, entry: ConfigEntry) -> 
 
 
 def _check_entity_source_availability(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Check if configured entity date sources exist and update Repairs issue accordingly.
+    """Check configured entity date sources and update Repairs issue accordingly.
 
-    Called on every entry setup (including HA restarts) to ensure the Repairs issue
-    accurately reflects the current state:
-    - Any source entity missing → create/keep the issue
-    - All source entities present (or no entity sources configured) → delete the issue
+    Called on every entry setup (including HA restarts and retries). When sources are
+    missing, also registers a one-shot restore listener so the Repairs issue is cleared
+    immediately when the entity comes back — even while the entry is in retry mode
+    (where _setup_entity_registry_listener is not yet active).
+
+    The restore listener triggers an immediate reload so the coordinator picks up the
+    restored entity without waiting for the next retry cycle.
     """
+    # Cancel any restore listener from a previous setup attempt (handles retry cycles)
+    restore_listeners: dict = hass.data[DOMAIN].setdefault(_RESTORE_LISTENER_KEY, {})
+    if old_unsub := restore_listeners.pop(entry.entry_id, None):
+        old_unsub()
+
     source_map = _get_source_entity_map(entry.data)
 
     if not source_map:
@@ -277,6 +288,22 @@ def _check_entity_source_availability(hass: HomeAssistant, entry: ConfigEntry) -
                 "entity_id": missing[0],
             },
         )
+
+        missing_set = set(missing)
+
+        @callback
+        def _on_entity_restored(event: Any) -> None:  # noqa: ANN401
+            if event.data.get("action") != "create":
+                return
+            if event.data.get("entity_id") not in missing_set:
+                return
+            if unsub := restore_listeners.pop(entry.entry_id, None):
+                unsub()
+            async_delete_issue(hass, DOMAIN, f"entity_deleted_{entry.entry_id}")
+            hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
+
+        unsub = hass.bus.async_listen(er.EVENT_ENTITY_REGISTRY_UPDATED, _on_entity_restored)
+        restore_listeners[entry.entry_id] = unsub
     else:
         async_delete_issue(hass, DOMAIN, f"entity_deleted_{entry.entry_id}")
 
@@ -344,7 +371,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         async_delete_issue(hass, DOMAIN, f"expired_{entry.entry_id}")
         async_delete_issue(hass, DOMAIN, f"date_order_{entry.entry_id}")
 
-        hass.data[DOMAIN].pop(entry.entry_id)
+        # Cancel entity restore listener if present (registered while in retry mode)
+        restore_listeners = hass.data[DOMAIN].get(_RESTORE_LISTENER_KEY, {})
+        if unsub := restore_listeners.pop(entry.entry_id, None):
+            unsub()
+
+        hass.data[DOMAIN].pop(entry.entry_id, None)
 
         entity_registry = er.async_get(hass)
         entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)

--- a/custom_components/whenhub/__init__.py
+++ b/custom_components/whenhub/__init__.py
@@ -135,6 +135,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await hass.config_entries.async_forward_entry_setups(entry, CALENDAR_PLATFORMS)
     else:
         # Event entry: existing behavior unchanged
+        _check_entity_source_availability(hass, entry)
         coordinator = WhenHubCoordinator(hass, entry, dict(entry.data))
         await coordinator.async_config_entry_first_refresh()
         hass.data[DOMAIN][entry.entry_id] = {
@@ -143,7 +144,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         }
         _setup_entity_date_listeners(hass, entry, coordinator)
         _setup_entity_registry_listener(hass, entry)
-        async_delete_issue(hass, DOMAIN, f"entity_deleted_{entry.entry_id}")
         await hass.config_entries.async_forward_entry_setups(entry, EVENT_PLATFORMS)
 
     entry.async_on_unload(entry.add_update_listener(async_update_listener))
@@ -247,6 +247,40 @@ def _setup_entity_registry_listener(hass: HomeAssistant, entry: ConfigEntry) -> 
     )
 
 
+def _check_entity_source_availability(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Check if configured entity date sources exist and update Repairs issue accordingly.
+
+    Called on every entry setup (including HA restarts) to ensure the Repairs issue
+    accurately reflects the current state:
+    - Any source entity missing → create/keep the issue
+    - All source entities present (or no entity sources configured) → delete the issue
+    """
+    source_map = _get_source_entity_map(entry.data)
+
+    if not source_map:
+        async_delete_issue(hass, DOMAIN, f"entity_deleted_{entry.entry_id}")
+        return
+
+    entity_reg = er.async_get(hass)
+    missing = [eid for eid in source_map.values() if entity_reg.async_get(eid) is None]
+
+    if missing:
+        async_create_issue(
+            hass,
+            DOMAIN,
+            f"entity_deleted_{entry.entry_id}",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="entity_source_deleted",
+            translation_placeholders={
+                "name": entry.title,
+                "entity_id": missing[0],
+            },
+        )
+    else:
+        async_delete_issue(hass, DOMAIN, f"entity_deleted_{entry.entry_id}")
+
+
 def _setup_entity_date_listeners(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -309,7 +343,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Clean up any open Repairs issues for this entry
         async_delete_issue(hass, DOMAIN, f"expired_{entry.entry_id}")
         async_delete_issue(hass, DOMAIN, f"date_order_{entry.entry_id}")
-        async_delete_issue(hass, DOMAIN, f"entity_deleted_{entry.entry_id}")
 
         hass.data[DOMAIN].pop(entry.entry_id)
 

--- a/custom_components/whenhub/__init__.py
+++ b/custom_components/whenhub/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.helpers.issue_registry import async_delete_issue
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue, async_delete_issue
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
@@ -142,6 +142,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "event_data": dict(entry.data),
         }
         _setup_entity_date_listeners(hass, entry, coordinator)
+        _setup_entity_registry_listener(hass, entry)
+        async_delete_issue(hass, DOMAIN, f"entity_deleted_{entry.entry_id}")
         await hass.config_entries.async_forward_entry_setups(entry, EVENT_PLATFORMS)
 
     entry.async_on_unload(entry.add_update_listener(async_update_listener))
@@ -165,6 +167,84 @@ async def async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None
     await hass.config_entries.async_reload(entry.entry_id)
 
     _LOGGER.info("WhenHub integration updated: %s", entry.title)
+
+
+def _get_source_entity_map(data: dict) -> dict[str, str]:
+    """Return {config_key: entity_id} for all active entity date sources."""
+    result: dict[str, str] = {}
+    for use_key, id_key in (
+        (CONF_EVENT_DATE_USE_ENTITY, CONF_EVENT_DATE_ENTITY_ID),
+        (CONF_START_DATE_USE_ENTITY, CONF_START_DATE_ENTITY_ID),
+        (CONF_END_DATE_USE_ENTITY, CONF_END_DATE_ENTITY_ID),
+    ):
+        if data.get(use_key) and data.get(id_key):
+            result[id_key] = data[id_key]
+    return result
+
+
+def _setup_entity_registry_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Register entity registry listener to track renames and deletions of entity date sources.
+
+    - On rename (action="update", entity_id changed): auto-migrates config entry data.
+    - On delete (action="remove"): creates a Repairs issue.
+    - On create (action="create"): auto-resolves a previous Repairs issue.
+
+    The listener is automatically removed when the entry is unloaded via entry.async_on_unload().
+    """
+    if not _get_source_entity_map(entry.data):
+        return
+
+    @callback
+    def _handle_entity_registry_update(event: Any) -> None:  # noqa: ANN401
+        action = event.data.get("action")
+        source_map = _get_source_entity_map(entry.data)
+
+        if action == "update":
+            changes = event.data.get("changes", {})
+            if "entity_id" not in changes:
+                return
+            old_entity_id = changes["entity_id"]
+            new_entity_id = event.data["entity_id"]
+
+            affected_keys = [k for k, v in source_map.items() if v == old_entity_id]
+            if not affected_keys:
+                return
+
+            new_data = dict(entry.data)
+            for key in affected_keys:
+                new_data[key] = new_entity_id
+            hass.config_entries.async_update_entry(entry, data=new_data)
+
+        elif action == "remove":
+            deleted_entity_id = event.data["entity_id"]
+            if deleted_entity_id not in source_map.values():
+                return
+
+            async_create_issue(
+                hass,
+                DOMAIN,
+                f"entity_deleted_{entry.entry_id}",
+                is_fixable=False,
+                severity=IssueSeverity.WARNING,
+                translation_key="entity_source_deleted",
+                translation_placeholders={
+                    "name": entry.title,
+                    "entity_id": deleted_entity_id,
+                },
+            )
+
+        elif action == "create":
+            new_entity_id = event.data["entity_id"]
+            if new_entity_id not in source_map.values():
+                return
+
+            async_delete_issue(hass, DOMAIN, f"entity_deleted_{entry.entry_id}")
+            coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+            hass.async_create_task(coordinator.async_request_refresh())
+
+    entry.async_on_unload(
+        hass.bus.async_listen(er.EVENT_ENTITY_REGISTRY_UPDATED, _handle_entity_registry_update)
+    )
 
 
 def _setup_entity_date_listeners(
@@ -229,6 +309,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Clean up any open Repairs issues for this entry
         async_delete_issue(hass, DOMAIN, f"expired_{entry.entry_id}")
         async_delete_issue(hass, DOMAIN, f"date_order_{entry.entry_id}")
+        async_delete_issue(hass, DOMAIN, f"entity_deleted_{entry.entry_id}")
 
         hass.data[DOMAIN].pop(entry.entry_id)
 

--- a/custom_components/whenhub/translations/de.json
+++ b/custom_components/whenhub/translations/de.json
@@ -733,7 +733,7 @@
     },
     "entity_source_deleted": {
       "title": "Datumsquellen-Entity entfernt: {name}",
-      "description": "Die Entity **{entity_id}**, die als Datumsquelle für **{name}** konfiguriert ist, wurde aus Home Assistant entfernt.\n\nAlle Sensoren für dieses Ereignis sind derzeit nicht verfügbar. Öffne die Einstellungen des Ereignisses und wähle eine andere Entity oder gib ein festes Datum ein."
+      "description": "Die Entity **{entity_id}**, die als Datumsquelle für **{name}** konfiguriert ist, wurde aus Home Assistant entfernt.\n\nAlle Sensoren für dieses Ereignis sind derzeit nicht verfügbar. Um das Problem zu beheben öffne die Einstellungen des Ereignisses und wähle eine andere Entity, gib ein festes Datum ein oder lösche das Ereignis."
     }
   }
 }

--- a/custom_components/whenhub/translations/de.json
+++ b/custom_components/whenhub/translations/de.json
@@ -730,6 +730,10 @@
     "date_order_invalid": {
       "title": "Trip-Datumsreihenfolge ungültig: {event_name}",
       "description": "Das entity-basierte Enddatum (**{end_date}**) liegt vor dem Startdatum (**{start_date}**) für **{event_name}**.\n\nAlle Sensoren dieses Trips sind derzeit nicht verfügbar. Passe die Quell-Entities so an, dass das Enddatum nach dem Startdatum liegt — das Problem wird dann automatisch behoben."
+    },
+    "entity_source_deleted": {
+      "title": "Datumsquellen-Entity entfernt: {name}",
+      "description": "Die Entity **{entity_id}**, die als Datumsquelle für **{name}** konfiguriert ist, wurde aus Home Assistant entfernt.\n\nAlle Sensoren für dieses Ereignis sind derzeit nicht verfügbar. Öffne die Einstellungen des Ereignisses und wähle eine andere Entity oder gib ein festes Datum ein."
     }
   }
 }

--- a/custom_components/whenhub/translations/en.json
+++ b/custom_components/whenhub/translations/en.json
@@ -733,7 +733,7 @@
     },
     "entity_source_deleted": {
       "title": "Date source entity removed: {name}",
-      "description": "The entity **{entity_id}** used as a date source for **{name}** has been removed from Home Assistant.\n\nAll sensors for this event are currently unavailable. Open the event's settings and either choose a different entity or enter a fixed date to resolve this issue."
+      "description": "The entity **{entity_id}** used as a date source for **{name}** has been removed from Home Assistant.\n\nAll sensors for this event are currently unavailable. To resolve this issue, open the event's settings and either choose a different entity, enter a fixed date, or delete the event."
     }
   }
 }

--- a/custom_components/whenhub/translations/en.json
+++ b/custom_components/whenhub/translations/en.json
@@ -730,6 +730,10 @@
     "date_order_invalid": {
       "title": "Trip date order invalid: {event_name}",
       "description": "The entity-sourced end date (**{end_date}**) is before the start date (**{start_date}**) for **{event_name}**.\n\nAll sensors for this trip are currently unavailable. Update the source entities so that the end date is after the start date to resolve this issue automatically."
+    },
+    "entity_source_deleted": {
+      "title": "Date source entity removed: {name}",
+      "description": "The entity **{entity_id}** used as a date source for **{name}** has been removed from Home Assistant.\n\nAll sensors for this event are currently unavailable. Open the event's settings and either choose a different entity or enter a fixed date to resolve this issue."
     }
   }
 }

--- a/tests/test_entity_registry_tracking.py
+++ b/tests/test_entity_registry_tracking.py
@@ -1,0 +1,361 @@
+"""Tests for FR19: Entity registry tracking for entity-based date sources.
+
+Tests:
+- _get_source_entity_map() helper function
+- _setup_entity_registry_listener() registration logic
+- Callback: rename (action="update") → auto-migration
+- Callback: delete (action="remove") → Repairs issue created
+- Callback: create/restore (action="create") → Repairs issue auto-resolved
+- Data correctness after auto-migration
+"""
+from __future__ import annotations
+
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from custom_components.whenhub.const import (
+    DOMAIN,
+    CONF_EVENT_DATE_USE_ENTITY,
+    CONF_EVENT_DATE_ENTITY_ID,
+    CONF_START_DATE_USE_ENTITY,
+    CONF_START_DATE_ENTITY_ID,
+    CONF_END_DATE_USE_ENTITY,
+    CONF_END_DATE_ENTITY_ID,
+)
+from custom_components.whenhub import _get_source_entity_map, _setup_entity_registry_listener
+
+
+# ---------------------------------------------------------------------------
+# Patch targets (functions imported into custom_components/whenhub/__init__.py)
+# ---------------------------------------------------------------------------
+
+PATCH_CREATE = "custom_components.whenhub.async_create_issue"
+PATCH_DELETE = "custom_components.whenhub.async_delete_issue"
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+class _FakeEntry:
+    def __init__(self, entry_id="test_id", title="Test Event", data=None):
+        self.entry_id = entry_id
+        self.title = title
+        self.data = data or {}
+        self.async_on_unload = MagicMock()
+
+
+class _FakeHass:
+    def __init__(self, entry_id="test_id"):
+        self.bus = MagicMock()
+        self.config_entries = MagicMock()
+        self.async_create_task = MagicMock()
+        self.data = {DOMAIN: {entry_id: {"coordinator": MagicMock()}}}
+
+
+def _make_event(action: str, entity_id: str, changes: dict | None = None) -> MagicMock:
+    """Build a minimal entity-registry event mock."""
+    event = MagicMock()
+    event.data = {"action": action, "entity_id": entity_id}
+    if changes is not None:
+        event.data["changes"] = changes
+    return event
+
+
+def _setup_and_get_callback(hass: _FakeHass, entry: _FakeEntry):
+    """Register listener and return the captured callback (None when not registered)."""
+    captured = [None]
+
+    def _capture(event_name, callback):
+        captured[0] = callback
+        return MagicMock()
+
+    hass.bus.async_listen.side_effect = _capture
+    _setup_entity_registry_listener(hass, entry)
+    return captured[0]
+
+
+# ---------------------------------------------------------------------------
+# _get_source_entity_map
+# ---------------------------------------------------------------------------
+
+class TestGetSourceEntityMap:
+    """Unit tests for the _get_source_entity_map() helper."""
+
+    def test_empty_data_returns_empty(self):
+        assert _get_source_entity_map({}) == {}
+
+    def test_milestone_entity_source(self):
+        data = {CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"}
+        assert _get_source_entity_map(data) == {CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"}
+
+    def test_trip_start_only(self):
+        data = {CONF_START_DATE_USE_ENTITY: True, CONF_START_DATE_ENTITY_ID: "sensor.dep"}
+        assert _get_source_entity_map(data) == {CONF_START_DATE_ENTITY_ID: "sensor.dep"}
+
+    def test_trip_end_only(self):
+        data = {CONF_END_DATE_USE_ENTITY: True, CONF_END_DATE_ENTITY_ID: "sensor.ret"}
+        assert _get_source_entity_map(data) == {CONF_END_DATE_ENTITY_ID: "sensor.ret"}
+
+    def test_trip_both_sources(self):
+        data = {
+            CONF_START_DATE_USE_ENTITY: True, CONF_START_DATE_ENTITY_ID: "sensor.dep",
+            CONF_END_DATE_USE_ENTITY: True, CONF_END_DATE_ENTITY_ID: "sensor.ret",
+        }
+        assert _get_source_entity_map(data) == {
+            CONF_START_DATE_ENTITY_ID: "sensor.dep",
+            CONF_END_DATE_ENTITY_ID: "sensor.ret",
+        }
+
+    def test_use_entity_false_excluded(self):
+        data = {CONF_EVENT_DATE_USE_ENTITY: False, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"}
+        assert _get_source_entity_map(data) == {}
+
+    def test_missing_entity_id_excluded(self):
+        data = {CONF_EVENT_DATE_USE_ENTITY: True}
+        assert _get_source_entity_map(data) == {}
+
+
+# ---------------------------------------------------------------------------
+# Listener registration
+# ---------------------------------------------------------------------------
+
+class TestListenerRegistration:
+    """_setup_entity_registry_listener() registers only when entity sources exist."""
+
+    def test_registers_listener_when_entity_source_present(self):
+        entry = _FakeEntry(data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.x"})
+        hass = _FakeHass(entry.entry_id)
+
+        _setup_entity_registry_listener(hass, entry)
+
+        hass.bus.async_listen.assert_called_once()
+        entry.async_on_unload.assert_called_once()
+
+    def test_no_listener_without_entity_source(self):
+        entry = _FakeEntry(data={"event_type": "milestone", "target_date": "2025-01-01"})
+        hass = _FakeHass(entry.entry_id)
+
+        _setup_entity_registry_listener(hass, entry)
+
+        hass.bus.async_listen.assert_not_called()
+        entry.async_on_unload.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Rename (action="update")
+# ---------------------------------------------------------------------------
+
+class TestEntityRename:
+    """Auto-migration when entity-id changes in the registry."""
+
+    def test_rename_milestone_entity_updates_config_data(self):
+        entry = _FakeEntry(data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.old"})
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        cb(_make_event("update", "sensor.new", changes={"entity_id": "sensor.old"}))
+
+        hass.config_entries.async_update_entry.assert_called_once()
+        new_data = hass.config_entries.async_update_entry.call_args[1]["data"]
+        assert new_data[CONF_EVENT_DATE_ENTITY_ID] == "sensor.new"
+
+    def test_rename_trip_start_entity_updates_config_data(self):
+        entry = _FakeEntry(data={
+            CONF_START_DATE_USE_ENTITY: True, CONF_START_DATE_ENTITY_ID: "sensor.dep_old",
+            CONF_END_DATE_USE_ENTITY: True, CONF_END_DATE_ENTITY_ID: "sensor.ret",
+        })
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        cb(_make_event("update", "sensor.dep_new", changes={"entity_id": "sensor.dep_old"}))
+
+        new_data = hass.config_entries.async_update_entry.call_args[1]["data"]
+        assert new_data[CONF_START_DATE_ENTITY_ID] == "sensor.dep_new"
+        assert new_data[CONF_END_DATE_ENTITY_ID] == "sensor.ret"
+
+    def test_rename_trip_end_entity_updates_config_data(self):
+        entry = _FakeEntry(data={
+            CONF_START_DATE_USE_ENTITY: True, CONF_START_DATE_ENTITY_ID: "sensor.dep",
+            CONF_END_DATE_USE_ENTITY: True, CONF_END_DATE_ENTITY_ID: "sensor.ret_old",
+        })
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        cb(_make_event("update", "sensor.ret_new", changes={"entity_id": "sensor.ret_old"}))
+
+        new_data = hass.config_entries.async_update_entry.call_args[1]["data"]
+        assert new_data[CONF_END_DATE_ENTITY_ID] == "sensor.ret_new"
+        assert new_data[CONF_START_DATE_ENTITY_ID] == "sensor.dep"
+
+    def test_rename_non_source_entity_no_change(self):
+        entry = _FakeEntry(data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"})
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        cb(_make_event("update", "sensor.other_new", changes={"entity_id": "sensor.other_old"}))
+
+        hass.config_entries.async_update_entry.assert_not_called()
+
+    def test_update_without_entity_id_in_changes_is_ignored(self):
+        """Only changes containing 'entity_id' trigger migration (e.g. name changes are skipped)."""
+        entry = _FakeEntry(data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"})
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        cb(_make_event("update", "sensor.bday", changes={"name": "old name"}))
+
+        hass.config_entries.async_update_entry.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Delete (action="remove")
+# ---------------------------------------------------------------------------
+
+class TestEntityDelete:
+    """Repairs issue is created when a source entity is removed."""
+
+    def test_delete_milestone_entity_creates_repair(self):
+        entry = _FakeEntry(
+            entry_id="abc123", title="My Birthday",
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        with patch(PATCH_CREATE) as mock_create:
+            cb(_make_event("remove", "sensor.bday"))
+
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args[1]
+        assert kwargs["translation_key"] == "entity_source_deleted"
+        assert kwargs["is_fixable"] is False
+        assert kwargs["translation_placeholders"]["name"] == "My Birthday"
+        assert kwargs["translation_placeholders"]["entity_id"] == "sensor.bday"
+
+    def test_delete_uses_correct_issue_id(self):
+        entry = _FakeEntry(
+            entry_id="uniquekey",
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        with patch(PATCH_CREATE) as mock_create:
+            cb(_make_event("remove", "sensor.bday"))
+
+        positional = mock_create.call_args[0]
+        assert positional[2] == "entity_deleted_uniquekey"
+
+    def test_delete_non_source_entity_no_repair(self):
+        entry = _FakeEntry(data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"})
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        with patch(PATCH_CREATE) as mock_create:
+            cb(_make_event("remove", "sensor.unrelated"))
+
+        mock_create.assert_not_called()
+
+    def test_delete_trip_start_entity_creates_repair(self):
+        entry = _FakeEntry(
+            entry_id="trip1", title="My Trip",
+            data={
+                CONF_START_DATE_USE_ENTITY: True, CONF_START_DATE_ENTITY_ID: "sensor.dep",
+                CONF_END_DATE_USE_ENTITY: True, CONF_END_DATE_ENTITY_ID: "sensor.ret",
+            },
+        )
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        with patch(PATCH_CREATE) as mock_create:
+            cb(_make_event("remove", "sensor.dep"))
+
+        mock_create.assert_called_once()
+        assert mock_create.call_args[1]["translation_placeholders"]["entity_id"] == "sensor.dep"
+
+
+# ---------------------------------------------------------------------------
+# Create / restore (action="create")
+# ---------------------------------------------------------------------------
+
+class TestEntityCreate:
+    """Repairs issue is auto-resolved when source entity comes back."""
+
+    def test_restore_source_entity_deletes_repair(self):
+        entry = _FakeEntry(
+            entry_id="abc123",
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        with patch(PATCH_DELETE) as mock_delete:
+            cb(_make_event("create", "sensor.bday"))
+
+        mock_delete.assert_called_once_with(hass, DOMAIN, "entity_deleted_abc123")
+
+    def test_restore_source_entity_triggers_coordinator_refresh(self):
+        entry = _FakeEntry(
+            entry_id="abc123",
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        with patch(PATCH_DELETE):
+            cb(_make_event("create", "sensor.bday"))
+
+        hass.async_create_task.assert_called_once()
+
+    def test_create_non_source_entity_no_effect(self):
+        entry = _FakeEntry(data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"})
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        with patch(PATCH_DELETE) as mock_delete:
+            cb(_make_event("create", "sensor.unrelated"))
+
+        mock_delete.assert_not_called()
+        hass.async_create_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Auto-migration data correctness
+# ---------------------------------------------------------------------------
+
+class TestAutoMigrate:
+    """Config entry data is correctly updated on rename, preserving all other fields."""
+
+    def test_migrated_data_preserves_other_fields(self):
+        entry = _FakeEntry(data={
+            CONF_EVENT_DATE_USE_ENTITY: True,
+            CONF_EVENT_DATE_ENTITY_ID: "sensor.old",
+            "event_type": "milestone",
+            "other_field": "preserved",
+        })
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        cb(_make_event("update", "sensor.new", changes={"entity_id": "sensor.old"}))
+
+        new_data = hass.config_entries.async_update_entry.call_args[1]["data"]
+        assert new_data["event_type"] == "milestone"
+        assert new_data["other_field"] == "preserved"
+        assert new_data[CONF_EVENT_DATE_ENTITY_ID] == "sensor.new"
+
+    def test_async_update_entry_receives_entry_reference(self):
+        """async_update_entry is called with the correct entry object."""
+        entry = _FakeEntry(data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.old"})
+        hass = _FakeHass(entry.entry_id)
+        cb = _setup_and_get_callback(hass, entry)
+
+        cb(_make_event("update", "sensor.new", changes={"entity_id": "sensor.old"}))
+
+        call_positional = hass.config_entries.async_update_entry.call_args[0]
+        assert call_positional[0] is entry

--- a/tests/test_entity_registry_tracking.py
+++ b/tests/test_entity_registry_tracking.py
@@ -32,6 +32,7 @@ from custom_components.whenhub import (
     _get_source_entity_map,
     _setup_entity_registry_listener,
     _check_entity_source_availability,
+    _RESTORE_LISTENER_KEY,
 )
 
 
@@ -457,3 +458,140 @@ class TestCheckEntitySourceAvailability:
             _check_entity_source_availability(hass, entry)
 
         mock_delete.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Restore listener (registered when entity is missing, for retry-mode resolution)
+# ---------------------------------------------------------------------------
+
+def _call_check_and_get_restore_cb(hass: _FakeHass, entry: _FakeEntry, missing_ids: list[str]):
+    """Run _check_entity_source_availability with missing entities and return restore callback."""
+    captured = [None]
+
+    def capture_listen(event_name, cb):
+        captured[0] = cb
+        return MagicMock()
+
+    hass.bus.async_listen.side_effect = capture_listen
+
+    with patch(PATCH_ER_GET, return_value=_make_entity_reg([])), \
+         patch(PATCH_CREATE), patch(PATCH_DELETE):
+        _check_entity_source_availability(hass, entry)
+
+    return captured[0]
+
+
+class TestRestoreListener:
+    """One-shot listener registered while entry is in retry mode."""
+
+    def test_restore_listener_registered_when_entity_missing(self):
+        entry = _FakeEntry(
+            entry_id="abc123",
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+
+        with patch(PATCH_ER_GET, return_value=_make_entity_reg([])), \
+             patch(PATCH_CREATE), patch(PATCH_DELETE):
+            _check_entity_source_availability(hass, entry)
+
+        hass.bus.async_listen.assert_called_once()
+        assert hass.data[DOMAIN][_RESTORE_LISTENER_KEY].get("abc123") is not None
+
+    def test_restore_listener_not_registered_when_entity_present(self):
+        entry = _FakeEntry(
+            entry_id="abc123",
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+
+        with patch(PATCH_ER_GET, return_value=_make_entity_reg(["sensor.bday"])), \
+             patch(PATCH_DELETE), patch(PATCH_CREATE):
+            _check_entity_source_availability(hass, entry)
+
+        hass.bus.async_listen.assert_not_called()
+
+    def test_restore_listener_fires_on_correct_entity_create(self):
+        """When missing entity is created → issue deleted + reload triggered."""
+        entry = _FakeEntry(
+            entry_id="abc123",
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+        cb = _call_check_and_get_restore_cb(hass, entry, ["sensor.bday"])
+
+        with patch(PATCH_DELETE) as mock_delete:
+            cb(_make_event("create", "sensor.bday"))
+
+        mock_delete.assert_called_once_with(hass, DOMAIN, "entity_deleted_abc123")
+        hass.async_create_task.assert_called_once()
+
+    def test_restore_listener_ignores_remove_action(self):
+        entry = _FakeEntry(
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+        cb = _call_check_and_get_restore_cb(hass, entry, ["sensor.bday"])
+
+        with patch(PATCH_DELETE) as mock_delete:
+            cb(_make_event("remove", "sensor.bday"))
+
+        mock_delete.assert_not_called()
+        hass.async_create_task.assert_not_called()
+
+    def test_restore_listener_ignores_update_action(self):
+        entry = _FakeEntry(
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+        cb = _call_check_and_get_restore_cb(hass, entry, ["sensor.bday"])
+
+        with patch(PATCH_DELETE) as mock_delete:
+            cb(_make_event("update", "sensor.bday", changes={"name": "old"}))
+
+        mock_delete.assert_not_called()
+        hass.async_create_task.assert_not_called()
+
+    def test_restore_listener_ignores_wrong_entity(self):
+        entry = _FakeEntry(
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+        cb = _call_check_and_get_restore_cb(hass, entry, ["sensor.bday"])
+
+        with patch(PATCH_DELETE) as mock_delete:
+            cb(_make_event("create", "sensor.unrelated"))
+
+        mock_delete.assert_not_called()
+        hass.async_create_task.assert_not_called()
+
+    def test_previous_restore_listener_canceled_on_retry(self):
+        """On each retry, old restore listener is unsubscribed before new one is registered."""
+        entry = _FakeEntry(
+            entry_id="abc123",
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+
+        old_unsub = MagicMock()
+        hass.data[DOMAIN].setdefault(_RESTORE_LISTENER_KEY, {})["abc123"] = old_unsub
+
+        with patch(PATCH_ER_GET, return_value=_make_entity_reg([])), \
+             patch(PATCH_CREATE), patch(PATCH_DELETE):
+            _check_entity_source_availability(hass, entry)
+
+        old_unsub.assert_called_once()
+
+    def test_restore_listener_unsubscribes_itself_on_fire(self):
+        """After firing, the listener removes itself from restore_listeners."""
+        entry = _FakeEntry(
+            entry_id="abc123",
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+        cb = _call_check_and_get_restore_cb(hass, entry, ["sensor.bday"])
+
+        with patch(PATCH_DELETE), patch(PATCH_CREATE):
+            cb(_make_event("create", "sensor.bday"))
+
+        assert "abc123" not in hass.data[DOMAIN].get(_RESTORE_LISTENER_KEY, {})

--- a/tests/test_entity_registry_tracking.py
+++ b/tests/test_entity_registry_tracking.py
@@ -6,6 +6,7 @@ Tests:
 - Callback: rename (action="update") → auto-migration
 - Callback: delete (action="remove") → Repairs issue created
 - Callback: create/restore (action="create") → Repairs issue auto-resolved
+- _check_entity_source_availability() — issue state on setup/restart
 - Data correctness after auto-migration
 """
 from __future__ import annotations
@@ -27,7 +28,11 @@ from custom_components.whenhub.const import (
     CONF_END_DATE_USE_ENTITY,
     CONF_END_DATE_ENTITY_ID,
 )
-from custom_components.whenhub import _get_source_entity_map, _setup_entity_registry_listener
+from custom_components.whenhub import (
+    _get_source_entity_map,
+    _setup_entity_registry_listener,
+    _check_entity_source_availability,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -359,3 +364,96 @@ class TestAutoMigrate:
 
         call_positional = hass.config_entries.async_update_entry.call_args[0]
         assert call_positional[0] is entry
+
+
+# ---------------------------------------------------------------------------
+# _check_entity_source_availability (called on every setup / HA restart)
+# ---------------------------------------------------------------------------
+
+PATCH_ER_GET = "custom_components.whenhub.er.async_get"
+
+
+def _make_entity_reg(existing_ids: list[str]) -> MagicMock:
+    """Return a mock entity registry where only the given IDs exist."""
+    reg = MagicMock()
+    reg.async_get = lambda eid: MagicMock() if eid in existing_ids else None
+    return reg
+
+
+class TestCheckEntitySourceAvailability:
+    """_check_entity_source_availability() recreates or clears the Repairs issue on setup."""
+
+    def test_missing_entity_creates_issue_on_setup(self):
+        """If source entity is absent from registry → create issue (e.g. after HA restart)."""
+        entry = _FakeEntry(
+            entry_id="abc123", title="My Birthday",
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+
+        with patch(PATCH_ER_GET, return_value=_make_entity_reg([])), \
+             patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE):
+            _check_entity_source_availability(hass, entry)
+
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args[1]
+        assert kwargs["translation_key"] == "entity_source_deleted"
+        assert kwargs["translation_placeholders"]["entity_id"] == "sensor.bday"
+
+    def test_present_entity_deletes_issue_on_setup(self):
+        """If source entity exists → delete any lingering issue."""
+        entry = _FakeEntry(
+            entry_id="abc123",
+            data={CONF_EVENT_DATE_USE_ENTITY: True, CONF_EVENT_DATE_ENTITY_ID: "sensor.bday"},
+        )
+        hass = _FakeHass(entry.entry_id)
+
+        with patch(PATCH_ER_GET, return_value=_make_entity_reg(["sensor.bday"])), \
+             patch(PATCH_DELETE) as mock_delete, patch(PATCH_CREATE):
+            _check_entity_source_availability(hass, entry)
+
+        mock_delete.assert_called_once_with(hass, DOMAIN, "entity_deleted_abc123")
+
+    def test_no_entity_source_deletes_lingering_issue(self):
+        """Entry without entity sources clears any leftover issue (e.g. user disabled source)."""
+        entry = _FakeEntry(entry_id="abc123", data={"event_type": "milestone"})
+        hass = _FakeHass(entry.entry_id)
+
+        with patch(PATCH_DELETE) as mock_delete, patch(PATCH_CREATE):
+            _check_entity_source_availability(hass, entry)
+
+        mock_delete.assert_called_once_with(hass, DOMAIN, "entity_deleted_abc123")
+
+    def test_trip_with_one_missing_source_creates_issue(self):
+        """Trip where only one source entity is missing still creates the issue."""
+        entry = _FakeEntry(
+            entry_id="trip1",
+            data={
+                CONF_START_DATE_USE_ENTITY: True, CONF_START_DATE_ENTITY_ID: "sensor.dep",
+                CONF_END_DATE_USE_ENTITY: True, CONF_END_DATE_ENTITY_ID: "sensor.ret",
+            },
+        )
+        hass = _FakeHass(entry.entry_id)
+
+        # Only start entity exists, end entity is gone
+        with patch(PATCH_ER_GET, return_value=_make_entity_reg(["sensor.dep"])), \
+             patch(PATCH_CREATE) as mock_create, patch(PATCH_DELETE):
+            _check_entity_source_availability(hass, entry)
+
+        mock_create.assert_called_once()
+
+    def test_trip_with_all_sources_present_deletes_issue(self):
+        entry = _FakeEntry(
+            entry_id="trip1",
+            data={
+                CONF_START_DATE_USE_ENTITY: True, CONF_START_DATE_ENTITY_ID: "sensor.dep",
+                CONF_END_DATE_USE_ENTITY: True, CONF_END_DATE_ENTITY_ID: "sensor.ret",
+            },
+        )
+        hass = _FakeHass(entry.entry_id)
+
+        with patch(PATCH_ER_GET, return_value=_make_entity_reg(["sensor.dep", "sensor.ret"])), \
+             patch(PATCH_DELETE) as mock_delete, patch(PATCH_CREATE):
+            _check_entity_source_availability(hass, entry)
+
+        mock_delete.assert_called_once()


### PR DESCRIPTION
## Summary

- Auto-migrates config entry data when a source entity is renamed (no user action needed)
- Creates a Repairs issue when a source entity is deleted from HA
- Repairs issue persists across HA restarts (checked via entity registry on every setup)
- Auto-resolves Repairs issue immediately when entity is restored — even while entry is in retry mode (one-shot restore listener triggers reload)
- 36 new tests covering all scenarios

## Details

### Rename (`action="update"`)
`_setup_entity_registry_listener` detects the entity_id change and calls `async_update_entry` with updated config data → triggers reload via update listener.

### Delete (`action="remove"`)
Creates `entity_deleted_{entry_id}` Repairs issue. On HA restart, `_check_entity_source_availability` recreates it if the entity is still missing from the registry.

### Restore (`action="create"`)
Two paths:
- Entry **loaded**: `_setup_entity_registry_listener` handles it → deletes issue + refreshes coordinator
- Entry **in retry mode**: one-shot restore listener (registered by `_check_entity_source_availability`) deletes issue + triggers immediate reload

## Test plan

- [x] 635 tests passing
- [x] Manually tested: delete entity → repair appears, HA restart → repair persists, recreate entity → repair disappears immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)